### PR TITLE
Support updates to permissions API + others

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -862,6 +862,27 @@ String representation of the entropy you have generated. **Must be 6 characters 
 
 * `err` - string representing the error message (or `null`)
 
+
+## <a href="permissions">permissions(cb)</a>
+
+Get a list of permissions associated with your permission.
+
+#### cb(err, permissions)
+
+* `err` - string representing the error message (or `null`)
+* `permissions` - array of permissions of form:
+
+```
+[{
+    schemaCode: <string>,
+    timeLimit: <int>,
+    params: <object>,
+}]
+```
+
+*Note that the params will be the same format that you specified when you created the permission via [addPermission](#add-permission).*
+
+
 ## <a href="sign">sign(options, cb)</a>
 
 Request a signature to be returned automatically (i.e. *without* user authorization). This must be requested within constraints of a pre-established permission.

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,14 +114,6 @@ If you receive a callback with `err==null`, the pairing has been made successful
 
 *NOTE: There is a timeout on the callback, so if the user does not enter the secret in 60 seconds, you will receive an error to that effect.*
 
-## Adding a Manual Permission
-
-**THIS WILL BE DEPRECATED SOON**
-
-```
-client.addManualPermission((err, res) => {
-})
-```
 
 ## <a href="getting-addresses">Getting Addresses</a>
 
@@ -172,7 +164,7 @@ const opts = {
 
 ### <a href="requesting-the-sig">Requesting the Signature</a>
 
-Without a specified permission, an SDK user with a pairing can always request a signature that the Lattice user can manually accept on the device (similar to the experience of other hardware wallets).
+Without a specified permission, an SDK user with a pairing can always request a signature that the Lattice user can manually accept on the device (similar to the experience of other hardware wallets). Note that if the user rejects the transaction, `signedTx=null` below.
 
 Once your transaction has been built by the SDK, you can send it to the device, which checks the boundaries of your request in the secure compute module and, if it conforms to the desired schema, is passed to the secure enclave for signing (pending user authorization).
 
@@ -265,7 +257,6 @@ With a permission in hand, an app can make a request in exactly the same way as 
 ```
 const schemaCode = 'ETH';
 const opts = {
-    usePermission: true,    // Needs to be true to request automated signature!
     schemaCode,
     params: {
       nonce: null,          // This will be filled in by the SDK
@@ -567,10 +558,6 @@ Retrieve one or more addresses from a paired device.
 * `addresses`: array of strings (if multiple) or a string (if one).
 
 
-## addManualPermission(cb)
-
-**This will be deprecated soon**
-
 ## <a href="add-permission">addPermission(param, cb)</a>
 
 Request a new permission based on a rule set you provide.
@@ -608,9 +595,10 @@ Request a new permission based on a rule set you provide.
     </tr>    
 </table>
 
-#### cb(err)
+#### cb(err, success)
 
 * `err`: string or `null`.
+* `success`: boolean indicating whether the user accepted the request
 
 ## <a href="broadcast">broadcast(shortcode, payload, cb)</a>
 
@@ -887,8 +875,7 @@ Required options:
     schemaCode: <string>,     // The schema code (e.g. ETH, ETH-ERC20, BTC)
     params: {
         ... // Set of parameters based on the type of request
-    },
-    usePermission: <bool>     // Default false, use true if you want to utilize an automatic signing permission
+    }
 }
 ```
 
@@ -930,7 +917,7 @@ Optional options:
 #### cb(err, sigData)
 
 * `err` - string representing the error message (or `null`)
-* `sigData` - object containing signature data which can be broadcast with `client.broadcast()`. Format depends on the network used:
+* `sigData` - object (or `null`, if the request has no matching permission and the user rejects it) containing signature data which can be broadcast with `client.broadcast()`. Format depends on the network used:
 
 *Bitcoin*:
 ```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "buildTokenList": "node support/getTokenList.js",
     "sendBTC": "node --require babel-core/register support/scripts/sendBTC.js",
     "sendETH": "node --require babel-core/register support/scripts/sendETH.js",
-    "test": "mocha --timeout 5000 -R spec --require babel-core/register test/local-*.js --recursive --exit",
+    "test": "mocha --timeout 15000 -R spec --require babel-core/register test/local-*.js --recursive --exit",
     "test:rinkeby": "mocha --timeout 60000 -R spec --require babel-core/register test/eth-rinkeby.js --recursive --exit",
     "test:bcy": "mocha --timeout 100000 -R spec --require babel-core/register test/btc-bcy.js --recursive --exit",
     "test:testnet3": "mocha --timeout 60000 -R spec --require babel-core/register test/btc-testnet3.js --recursive --exit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.0.6-development",
+  "version": "0.0.8-development",
   "description": "SDK to interact with GridPlus agent devices",
   "scripts": {
     "commit": "git-cz",

--- a/src/index.js
+++ b/src/index.js
@@ -184,13 +184,11 @@ export default class SdkClient {
 
   sign(param, cb) {
     const req = buildSigRequest(param);
-    const automated = param.usePermission ? param.usePermission : false;
-    const route = automated === true ? 'signAutomated' : 'signManual';
     if (typeof req === 'string') return cb(req);
     const providerCode = getProviderShortCode(param.schemaCode);
     this._getStatefulParams(providerCode, req, (err, newReq) => {
       if (err) return cb(err);
-      this.client.pairedRequest(route, { param: newReq }, (err, res) => {
+      this.client.pairedRequest('sign', { param: newReq }, (err, res) => {
         if (err) return cb(err)
         else if (!res || res.result === undefined || res.result.data === undefined || res.result.data.sigData === undefined) return cb('Incorrect response');
         

--- a/src/index.js
+++ b/src/index.js
@@ -50,17 +50,17 @@ export default class SdkClient {
     });
   }
 
-  addManualPermission(cb) {
-    this.client.pairedRequest('addManualPermission', { }, (err) => {
-      return cb(err);
-    });
-  }
-
   addPermission(param, cb) {
     const req = buildPermissionRequest(param);
     if (typeof req === 'string') return cb(req);
-    this.client.pairedRequest('addPermission', { param: req }, (err) => {
-      return cb(err);
+    this.client.pairedRequest('addPermission', { param: req }, (err, res) => {
+      let success = null;
+      try {
+        success = res.result.success;
+      } catch (e) {
+        ;
+      }
+      return cb(err, success);
     });
   }
 
@@ -190,6 +190,7 @@ export default class SdkClient {
       if (err) return cb(err);
       this.client.pairedRequest('sign', { param: newReq }, (err, res) => {
         if (err) return cb(err)
+        else if (res === null) return cb(null, null)   // User rejects request --> return no error and sigData=null
         else if (!res || res.result === undefined || res.result.data === undefined || res.result.data.sigData === undefined) return cb('Incorrect response');
         
         res.result.data.params = newReq.params;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export const providers = {
   Bitcoin,
   Ethereum,
 };
-import { buildPermissionRequest, buildSigRequest } from './permissions';
+import { buildPermissionRequest, buildSigRequest, parsePermissions } from './permissions';
 // const tokenList = require('../tokensByAddress.json')
 const log = debug('gridplus-sdk');
 
@@ -177,9 +177,18 @@ export default class SdkClient {
       return cb(null, info);
     }).catch(err => cb(err));
   }
-  // appSecret
+
   pair(appSecret, cb) {
     return this.client.pair(appSecret, cb);
+  }
+
+  permissions(cb) {
+    this.client.pairedRequest('getPermissions', { }, (err, res) => {
+      if (err) return cb(err);  
+      if (!res.result || !res.result.data) return cb('Incorrect response.');
+      if (!res.result.data.permissions) res.result.data.permissions = [];
+      return cb(null, parsePermissions(res.result.data.permissions));
+    });
   }
 
   sign(param, cb) {

--- a/src/permissions/codes.json
+++ b/src/permissions/codes.json
@@ -13,6 +13,15 @@
       "type": 2
     }
   },
+  "invCode": {
+    "0": {
+      "0": "ETH",
+      "1": "ETH-ERC20"
+    },
+    "1": {
+      "2": "BTC"
+    }
+  },
   "schemaTypes": {
     "0": [ "number", "number", "number", "string", "number", "string" ],
     "1": [ "number", "number", "string", "number", "number", "number" ]

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -1,4 +1,5 @@
-import { buildPermissionRequest, buildSigRequest } from './permissions';
+import { buildPermissionRequest, buildSigRequest, parsePermissions } from './permissions';
 
 exports.buildPermissionRequest = buildPermissionRequest;
 exports.buildSigRequest = buildSigRequest;
+exports.parsePermissions = parsePermissions;

--- a/test/btc-bcy.js
+++ b/test/btc-bcy.js
@@ -63,13 +63,6 @@ describe('Bitcoin via BlockCypher: transfers', () => {
     });
   });
 
-  it('Should create a manual permission', (done) => {
-    client.addManualPermission((err) => {
-      assert(err === null, err);
-      done();
-    })
-  });
-
   it('Should get the first 2 Bitcoin addresses of the manual permission and log address 0', (done) => {
     const req = {
       total: 2,

--- a/test/eth-rinkeby.js
+++ b/test/eth-rinkeby.js
@@ -9,17 +9,16 @@ const { erc20Src } = require('./config.json');
 const { ethHolder, etherscanApiKey } = require('../secrets.json');
 let client, addr, erc20Addr, sender, senderPriv, addr2;
 const transferAmount = 54;
+const providerOpts = {
+  network: 'rinkeby', 
+  etherscan: true, 
+  apiKey: etherscanApiKey 
+}
 
 describe('Ethereum via Etherscan: ether transfers', () => {
 
   before(() => {
-    const opts = {
-      network: 'rinkeby', 
-      etherscan: true, 
-      apiKey: etherscanApiKey 
-    }
-
-    const eth = new providers.Ethereum(opts);
+    const eth = new providers.Ethereum(providerOpts);
     client = new Client({
       clientConfig: {
         name: 'basic-test',
@@ -190,7 +189,7 @@ describe('Ethereum via Etherscan: ERC20 transfers',  () => {
 
   before(() => {
 
-    const eth = new providers.Ethereum({ network: 'rinkeby', etherscan: true });
+    const eth = new providers.Ethereum(providerOpts);
     client = new Client({
       clientConfig: {
         name: 'basic-test',

--- a/test/eth-rinkeby.js
+++ b/test/eth-rinkeby.js
@@ -57,13 +57,6 @@ describe('Ethereum via Etherscan: ether transfers', () => {
     });
   });
 
-  it('Should create a manual permission', (done) => {
-    client.addManualPermission((err) => {
-      assert(err === null, err);
-      done();
-    })
-  });
-
   it('Should get the Rinkeby balance of the holder account', (done) => {
     client.getBalance('ETH', { address: ethHolder.address }, (err, data) => {
       assert.equal(err, null, err);

--- a/test/local-agent.js
+++ b/test/local-agent.js
@@ -81,6 +81,14 @@ describe('Basic stateless tests (no providers)', () => {
     })
   });
 
+  it('Should find zero permissions saved', (done) => {
+    client.permissions((err, permissions) => {
+      assert(err === null, err);
+      assert(permissions.length === 0, 'Did not find zero permissions');
+      done();
+    })
+  })
+
   it('Should create an automated permission', (done) => {
     const req = {
       schemaCode: 'ETH',
@@ -103,6 +111,16 @@ describe('Basic stateless tests (no providers)', () => {
       done();
     })
   });
+
+  it('Should find one permission saved', (done) => {
+    client.permissions((err, permissions) => {
+      assert(err === null, err);
+      assert(permissions.length === 1, 'Did not find one permission');
+      assert(permissions[0].timeLimit === 10000, 'Incorrect timeLimit on permission');
+      assert(permissions[0].params.value.eq === 1000, 'Incorrect permission found');
+      done();
+    })
+  })
 
   it('Should get the Ethereum address and request a signature from it', (done) => {
     const req2 = {
@@ -180,4 +198,5 @@ describe('Basic stateless tests (no providers)', () => {
       done();
     });
   });
+  
 });

--- a/test/local-agent.js
+++ b/test/local-agent.js
@@ -6,7 +6,8 @@ import { Client } from 'index';
 import ReactNativeCrypto from 'gridplus-react-native-crypto';
 import crypto from 'crypto';
 
-let client, reactNative;
+let client, reactNative, btcAddrs, ethAddrs;
+process.on('unhandledRejection', e => { throw e; });
 
 describe('Basic stateless tests (no providers)', () => {
 
@@ -39,37 +40,45 @@ describe('Basic stateless tests (no providers)', () => {
     });
   });
 
-  it('Should create a manual permission', (done) => {
-    client.addManualPermission((err) => {
-      assert(err === null, err);
-      done();
-    })
-  });
-
-  it('Should get the Bitcoin addresses of the manual permission', (done) => {
+  it('Should get the Bitcoin addresses', (done) => {
     const req = {
-      total: 3,
+      total: 2,
     }
     client.addresses(req, (err, addresses) => {
       assert(err === null, err);
-      assert(addresses.length === 3);
+      assert(addresses.length === 2);
       assert(addresses[0].slice(0, 1) === '3', 'Not a segwit address');
+      btcAddrs = addresses;
       done();
     })
   });
 
   it('Should get testnet addresses', (done) => {
     const req = {
-      total: 3,
+      total: 2,
       network: 'testnet'
     }
     client.addresses(req, (err, addresses) => {
 
       assert(err === null, err);
-      assert(addresses.length === 3);
+      assert(addresses.length === 2);
       assert(addresses[0].slice(0, 1) === '2', 'Not a testnet address');
       done();
     });
+  });
+
+  it('Should get the Ethereum addresses', (done) => {
+    const req = {
+      total: 2,
+      coin_type: '60\'',
+    }
+    client.addresses(req, (err, addresses) => {
+      assert(err === null, err);
+      assert(addresses.length === 2);
+      assert(addresses[0].slice(0, 2) === '0x', 'Not an Ethereum address');
+      ethAddrs = addresses;
+      done();
+    })
   });
 
   it('Should create an automated permission', (done) => {
@@ -96,12 +105,7 @@ describe('Basic stateless tests (no providers)', () => {
   });
 
   it('Should get the Ethereum address and request a signature from it', (done) => {
-    // TODO: remove permissionIndex and isManual from request
-    const req1 = {
-      coin_type: '60\''
-    };
     const req2 = {
-      usePermission: true,
       schemaCode: 'ETH',
       params: {
         nonce: 1,   // Need to specify nonce in this test file because we have not instantied any providers
@@ -113,32 +117,27 @@ describe('Basic stateless tests (no providers)', () => {
       },
       accountIndex: 0
     }
-
-    client.addresses(req1, (err, address) => {
+    client.sign(req2, (err, sigData) => {
       assert(err === null, err);
-      client.sign(req2, (err, sigData) => {
-        assert(err === null, err);
-        // The message includes the preImage payload concatenated to a signature,
-        // separated by a standard string/buffer
-        const preImage = Buffer.from(sigData.unsignedTx, 'hex');
-        const msg = sha3(preImage);
-        const sig = sigData.sig;
-        assert(sig.length === 129, 'Incorrect signature length');
-        const parsedSig = {
-          r: sig.substr(0, 64),
-          s: sig.substr(64, 128),
-          v: parseInt(sig.slice(-1)),
-        } 
-        const recoveredPubKey = Buffer.from(recoverPubKey(msg, parsedSig), 'hex');
-        const recoveredAddress = `0x${pubToAddress(recoveredPubKey.slice(1)).toString('hex')}`;
-        assert(recoveredAddress === address, 'Incorrect signature');
-        done();
-      });
+      // The message includes the preImage payload concatenated to a signature,
+      // separated by a standard string/buffer
+      const preImage = Buffer.from(sigData.unsignedTx, 'hex');
+      const msg = sha3(preImage);
+      const sig = sigData.sig;
+      assert(sig.length === 129, 'Incorrect signature length');
+      const parsedSig = {
+        r: sig.substr(0, 64),
+        s: sig.substr(64, 128),
+        v: parseInt(sig.slice(-1)),
+      } 
+      const recoveredPubKey = Buffer.from(recoverPubKey(msg, parsedSig), 'hex');
+      const recoveredAddress = `0x${pubToAddress(recoveredPubKey.slice(1)).toString('hex')}`;
+      assert(recoveredAddress === ethAddrs[0], 'Incorrect signature');
+      done();
     });
   });
 
   it('Should create an automated permission to send Bitcoins', (done) => {
-
     const req = {
       schemaCode: 'BTC',
       timeLimit: 0,
@@ -148,7 +147,6 @@ describe('Basic stateless tests (no providers)', () => {
         value: { lte: 12000 },
       }
     };
-
     client.addPermission(req, (err) => {
       assert(err === null, err);
       done();
@@ -156,12 +154,8 @@ describe('Basic stateless tests (no providers)', () => {
   });
 
   it('Should create an automated Bitcoin transaction', (done) => {
-    const req1 = {
-      coin_type: '0\''
-    };
     // Build the request
-    const req2 = {
-      usePermission: true,
+    const req = {
       schemaCode: 'BTC',
       params: {
         version: 1,
@@ -180,16 +174,10 @@ describe('Basic stateless tests (no providers)', () => {
       }],
       accountIndex: 0,
     };
-    client.addresses(req1, (err, res) => {
+    client.sign(req, (err, sigData) => {
       assert(err === null, err);
-      assert(res !== undefined);
-      // const addr = res.result.data.addresses;
-      client.sign(req2, (err, sigData) => {
-        assert(err === null, err);
-        assert(sigData !== undefined);
-        done();
-      });
+      assert(sigData !== undefined);
+      done();
     });
   });
-
 });

--- a/test/local-btc.js
+++ b/test/local-btc.js
@@ -21,7 +21,7 @@ const regtest = {  // regtest config from bcoin: http://bcoin.io/docs/protocol_n
 import crypto from 'crypto';
 
 let deviceAddresses, startBal, startUtxos, TX_VALUE;
-const CHANGE_INDEX = 2
+const CHANGE_INDEX = 1
 
 const { host, network, port } = bitcoinNode;
 const { btcHolder }= require('../secrets.json');
@@ -139,21 +139,14 @@ describe('Bitcoin', () => {
     });
   });
 
-  it('Should create a manual permission', (done) => {
-    client.addManualPermission((err) => {
-      assert(err === null, err);
-      done();
-    })
-  });
-
   it('Should get the first 2 Bitcoin addresses of the manual permission and log address 0', (done) => {
     const req = {
-      total: 4,
+      total: 2,
       network: 'regtest'
     }
     client.addresses(req, (err, addresses) => {
       assert(err === null, err);
-      assert(addresses.length === 4);
+      assert(addresses.length === 2);
       deviceAddresses = addresses;
       // Get the baseline balance for the addresses
       client.getBalance('BTC', { address: deviceAddresses[0] }, (err, d) => {
@@ -308,7 +301,7 @@ describe('Bitcoin', () => {
 
   it('Should ensure the correct change address got the change', (done) => {
     const req = {
-      total: 4,
+      total: 2,
       network: 'regtest'
     }
     client.addresses(req, (err, addresses) => {

--- a/test/local-eth.js
+++ b/test/local-eth.js
@@ -52,13 +52,6 @@ describe('Ethereum', () => {
     });
   });
 
-  it('Should create a manual permission', (done) => {
-    client.addManualPermission((err) => {
-      assert(err === null, err);
-      done();
-    })
-  });
-
   it('Should get the ETH address', (done) => {
     const req = {
       total: 1,


### PR DESCRIPTION
This adds:

- Ability to get permissions
- Additional `success` callback param for `addPermission`
- Replacement of `txData` with `null` for `sign` in the event of a rejected manual signature