### PR TITLE
Add unstructured tx

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,35 +46,30 @@ const clientConfig = {
         <td>Param</td>
         <td>Type</td>
         <td>Default</td>
-        <td>Required</td>
         <td>Description</td>
     </tr>
     <tr>
         <td>baseUrl</td>
         <td>string</td>
         <td>`http://localhost`</td>
-        <td>No</td>
         <td>Hostname of Lattice request handler</td>
     </tr>
     <tr>
         <td>name</td>
         <td>string</td>
         <td>`gridplus-sdk`</td>
-        <td>No</td>
         <td>Name of the app. This will appear on the Lattice screen for requests. Not required, but strongly suggested.</td>
     </tr>
     <tr>
         <td>privKey</td>
         <td>Buffer</td>
-        <td> </td>
-        <td>Yes</td>
+        <td>Random</td>
         <td>Private key buffer used for encryption/decryption of Lattice messages</td>
     </tr>
     <tr>
         <td>crypto</td>
         <td>Object</td>
         <td>`NodeCrypto`</td>
-        <td>No</td>
         <td>Crypto function package. You only need to specify a different value if you are using React Native</td>
     </tr>
 </table>
@@ -119,7 +114,7 @@ clientConfig.crypto = cryptoLib;
 With the `clientConfig` filled out, you can initialize a new SDK object:
 
 ```
-const client = new Client({ clientConfig: clientConfig });
+const client = new Client(clientConfig);
 client.initialize((err, connections) => { })
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,9 +62,9 @@ const clientConfig = {
     </tr>
     <tr>
         <td>privKey</td>
-        <td>Buffer</td>
-        <td>Random</td>
-        <td>Private key buffer used for encryption/decryption of Lattice messages</td>
+        <td>String or Buffer</td>
+        <td></td>
+        <td>Private key buffer used for encryption/decryption of Lattice messages. A random private key will be generated and stored if none is provided.</td>
     </tr>
     <tr>
         <td>crypto</td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -457,7 +457,7 @@ const eth = new Ethereum(paramss);
 * `ropsten`
 * `homestead`: mainnet
 
-#<a name="Schema-Reference">Schema Reference</a>
+# Schema Reference
 
 This section outlines the schema types, param names, and restrictions for the accepted `schemaCodes`:
 
@@ -480,6 +480,13 @@ This section outlines the schema types, param names, and restrictions for the ac
 * Restrictions: `data` must be of form `{ to: <string>, value: <integer> }` where `to` is the recipient of the tokens and `value` is the number of tokens (atomic units) to send.
 
 **Note: ERC20 transfers require the `to` value in the `param` array to be the address of the token contract!**
+
+#### 'ETH-Unstructured': Unstructured Ethereum Contract Calls
+
+* Types: `[ "number", "number", "number", "string", "number", "string" ]`
+* ParamNames: `[ "nonce", "gasPrice", "gas", "to", "value", "data" ]`
+* Restrictions: No permissions allowed.
+
 
 *Bitcoin*
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,47 @@ const clientConfig = {
 }
 ```
 
+### Client options
+
+<table>
+    <tr>
+        <td>Param</td>
+        <td>Type</td>
+        <td>Default</td>
+        <td>Required</td>
+        <td>Description</td>
+    </tr>
+    <tr>
+        <td>baseUrl</td>
+        <td>string</td>
+        <td>`http://localhost`</td>
+        <td>No</td>
+        <td>Hostname of Lattice request handler</td>
+    </tr>
+    <tr>
+        <td>name</td>
+        <td>string</td>
+        <td>`gridplus-sdk`</td>
+        <td>No</td>
+        <td>Name of the app. This will appear on the Lattice screen for requests. Not required, but strongly suggested.</td>
+    </tr>
+    <tr>
+        <td>privKey</td>
+        <td>Buffer</td>
+        <td> </td>
+        <td>Yes</td>
+        <td>Private key buffer used for encryption/decryption of Lattice messages</td>
+    </tr>
+    <tr>
+        <td>crypto</td>
+        <td>Object</td>
+        <td>`NodeCrypto`</td>
+        <td>No</td>
+        <td>Crypto function package. You only need to specify a different value if you are using React Native</td>
+    </tr>
+</table>
+
+
 ### Adding Providers
 
 To connect the SDK to supported cryptocurrency networks, you will need to add *providers* to the `clientConfig`. We have two from which to choose:
@@ -63,7 +104,7 @@ clientConfig.providers = [ eth, btc ];
 To see the full list of configuration options for these providers (and how to add your own), please see the [Providers](#providers) section.
 
 
-### Adding Crypto Module [Optional]
+### Adding A Different Crypto Module [Optional]
 
 By default, this client will use the build in `node.js` [`crypto`](https://nodejs.org/api/crypto.html) module. If you are using React Native, you may want to add another option to the `clientConfig` which specifies a limited "crypto library". We have an [example library](https://github.com/GridPlus/gridplus-react-native-crypto), which you are free to use:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ If you get a non-error response, it means you can talk to the device.
 
 We can now *pair* with a Lattice device, which means establishing a permanent, secure channel between your app and the device. We do this by generating a 6-digit secret, signing it, and sending that signature (plus some other content) to the device. The user then enters the secret you generated into the device (out of band).
 
-*NOTE: The library of possible characters includes digits 0-9 and letters a-f,w,x,y,z (upper and lowercase), making it **base40**. You must generate a 6-digit secret that uses only these characters*
+*NOTE: The library of possible characters includes digits 0-9 and letters a-f,w,x,y,z (upper and lowercase), making it **base40**. You must generate a **6-digit** secret that uses only these characters*
 
 ```
 const secret = crypto.randomBytes(3).toString('hex');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "buildTokenList": "node support/getTokenList.js",
     "sendBTC": "node --require babel-core/register support/scripts/sendBTC.js",
     "sendETH": "node --require babel-core/register support/scripts/sendETH.js",
-    "test": "mocha --timeout 30000 -R spec --require babel-core/register test/local-*.js --recursive --exit",
+    "test": "mocha --timeout 30000 -R spec --require babel-core/register test/local-eth.js --recursive --exit",
     "test:rinkeby": "mocha --timeout 60000 -R spec --require babel-core/register test/eth-rinkeby.js --recursive --exit",
     "test:bcy": "mocha --timeout 100000 -R spec --require babel-core/register test/btc-bcy.js --recursive --exit",
     "test:testnet3": "mocha --timeout 60000 -R spec --require babel-core/register test/btc-testnet3.js --recursive --exit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.0.12-development",
+  "version": "0.0.13-development",
   "description": "SDK to interact with GridPlus agent devices",
   "scripts": {
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "buildTokenList": "node support/getTokenList.js",
     "sendBTC": "node --require babel-core/register support/scripts/sendBTC.js",
     "sendETH": "node --require babel-core/register support/scripts/sendETH.js",
-    "test": "mocha --timeout 30000 -R spec --require babel-core/register test/local-eth.js --recursive --exit",
+    "test": "mocha --timeout 30000 -R spec --require babel-core/register test/local-*.js --recursive --exit",
     "test:rinkeby": "mocha --timeout 60000 -R spec --require babel-core/register test/eth-rinkeby.js --recursive --exit",
     "test:bcy": "mocha --timeout 100000 -R spec --require babel-core/register test/btc-bcy.js --recursive --exit",
     "test:testnet3": "mocha --timeout 60000 -R spec --require babel-core/register test/btc-testnet3.js --recursive --exit",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import debug from 'debug';
 import Ethereum from './providers/Ethereum';
 import AgentRestClient from './rest/client';
 import { parseSigResponse, getProviderShortCode } from './util';
+import NodeCrypto from 'gridplus-node-crypto';
 export const providers = {
   Bitcoin,
   Ethereum,
@@ -21,10 +22,7 @@ export default class SdkClient {
     options.clientConfig.baseUrl = options.clientConfig.baseUrl || config.api.baseUrl;
     options.clientConfig.name = options.clientConfig.name || 'gridplus-sdk';
     options.clientConfig.privKey = options.clientConfig.privKey;
-
-    if ( ! options.clientConfig.crypto) {
-      throw new Error('options.clientConfig.crypto provider must be specified');
-    }
+    options.clientConfig.crypto = options.clientConfig.crypto || NodeCrypto;
 
     if ( ! options.clientConfig.privKey || options.clientConfig.privKey.length !== 64 || typeof options.clientConfig.privKey !== 'string') {
       throw new Error('options.clientConfig.privKey must be provided as a 32 byte hex string')

--- a/src/index.js
+++ b/src/index.js
@@ -18,17 +18,23 @@ export default class SdkClient {
   constructor(options) {
     options = options || {};
 
-    options.clientConfig = options.clientConfig || {};
-    options.clientConfig.baseUrl = options.clientConfig.baseUrl || config.api.baseUrl;
-    options.clientConfig.name = options.clientConfig.name || 'gridplus-sdk';
-    options.clientConfig.privKey = options.clientConfig.privKey;
-    options.clientConfig.crypto = options.clientConfig.crypto || NodeCrypto;
+    options = options || {};
+    options.baseUrl = options.baseUrl || config.api.baseUrl;
+    options.name = options.name || 'gridplus-sdk';
+    options.privKey = options.privKey;
+    options.crypto = options.crypto || NodeCrypto;
 
-    if ( ! options.clientConfig.privKey || options.clientConfig.privKey.length !== 64 || typeof options.clientConfig.privKey !== 'string') {
-      throw new Error('options.clientConfig.privKey must be provided as a 32 byte hex string')
+    if (!options.privKey) {
+      const priv = options.crypto.randomBytes(32);
+      if (typeof priv === 'string') options.privKey = priv
+      else                          options.privKey = priv.toString('hex');
+    } else {
+      const priv = typeof options.privKey === 'string' ? options.privKey : options.privKey.toString('hex');
+      if (priv.length != 64) throw new Error('options.privKey must be 32 bytes (hex encoding)');
+      options.privKey = priv;
     }
 
-    this.client = new AgentRestClient(options.clientConfig);
+    this.client = new AgentRestClient(options);
 
     this.providers = {};
 

--- a/src/permissions/codes.json
+++ b/src/permissions/codes.json
@@ -8,6 +8,10 @@
       "schema": 0,
       "type": 1
     },
+    "ETH-Unstructured": {
+      "schema": 0,
+      "type": 3
+    },
     "BTC": {
       "schema": 1,
       "type": 2
@@ -16,7 +20,8 @@
   "invCode": {
     "0": {
       "0": "ETH",
-      "1": "ETH-ERC20"
+      "1": "ETH-ERC20",
+      "2": "ETH-Unstructured"
     },
     "1": {
       "2": "BTC"
@@ -34,7 +39,8 @@
   "schemaNames": {
     "0": {
       "0": [ ["nonce", null], ["gasPrice", null], ["gas", null], ["to", null], ["value", null], ["data", null] ],
-      "1": [ ["nonce", null], ["gasPrice", null], ["gas", null], ["to", null], ["value", null], ["data", ["to", "value"]] ]
+      "1": [ ["nonce", null], ["gasPrice", null], ["gas", null], ["to", null], ["value", null], ["data", ["to", "value"]] ],
+      "3": [ ["nonce", null], ["gasPrice", null], ["gas", null], ["to", null], ["value", null], ["data", null] ]    
     },
     "1": {
       "2": [ ["version", null], ["lockTime", null], ["recipient", null], ["value", null], ["change", null], ["changeAccountIndex", null] ]

--- a/src/util.js
+++ b/src/util.js
@@ -21,6 +21,8 @@ export function getProviderShortCode(schemaCode) {
       return 'ETH';
     case 'ETH-ERC20':
       return 'ETH';
+    case 'ETH-Unstructured':
+      return 'ETH';
     case 'BTC':
       return 'BTC';
   }

--- a/test/local-agent.js
+++ b/test/local-agent.js
@@ -34,6 +34,7 @@ describe('Basic stateless tests (no providers)', () => {
 
   it('Should pair with the agent', (done) => {
     const appSecret = process.env.APP_SECRET;
+    
     client.pair(appSecret, (err) => {
       assert(err === null, err)
       done();

--- a/test/local-eth.js
+++ b/test/local-eth.js
@@ -47,6 +47,7 @@ describe('Ethereum', () => {
 
   it('Should pair with the agent', (done) => {
     const appSecret = process.env.APP_SECRET;
+    console.log('Pairing with secret', appSecret)
     client.pair(appSecret, (err) => {
       assert(err === null, err)
       done();
@@ -115,7 +116,7 @@ describe('Ethereum', () => {
       done();
     });
   });
-/*
+
   it('Should deploy an ERC20 token', (done) => {
     const tx = {
       nonce: null,
@@ -496,7 +497,6 @@ describe('Ethereum', () => {
       done();
     })
   })
-  */
 
   it('Should create an unstructured transaction', (done) => {
     client.providers.ETH.getNonce(addr)


### PR DESCRIPTION
Adds the ability to request a signature on an unstructured Ethereum transaction. In this case, the user specifies the raw data field, which is displayed on the device at the time of signing.

Note the permissions cannot be applied to unstructured transactions.