### PR TITLE
Removes `initialize` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ or, for older style syntax:
 const Sdk = require('gridplus-sdk').Client;
 ```
 
-### Initializing a Client
+### Instantiate a Client
 
-Once imported, you can initialize your SDK client with a `clientConfig` object, which at minimum requires the name of your app (`name`) and a private key with which to sign requests (`privKey`). The latter is not meant to e.g. hold onto any cryptocurrencies; it is simply a way of maintaining a secure communication channel between the device and your application.
+Once imported, you can instantiate your SDK client with a `clientConfig` object, which at minimum requires the name of your app (`name`) and a private key with which to sign requests (`privKey`). The latter is not meant to e.g. hold onto any cryptocurrencies; it is simply a way of maintaining a secure communication channel between the device and your application.
 
 ```
 const clientConfig = {
@@ -65,13 +65,12 @@ const btc = new providers.Bitcoin({
 clientConfig.providers = [ eth, btc ];
 ```
 
-#### Initialize!
+#### Instantiate
 
-With the `clientConfig` filled out, you can initialize a new SDK object:
+With the `clientConfig` filled out, you can instantiate a new SDK client object:
 
 ```
 const client = new Client(clientConfig);
-client.initialize((err, connections) => { })
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,9 @@ or, for older style syntax:
 const Sdk = require('gridplus-sdk').Client;
 ```
 
-## Initializing a Client
+## Instantiating a Client
 
-Once imported, you can initialize your SDK client with a `clientConfig` object, which at minimum requires the name of your app (`name`) and a private key with which to sign requests (`privKey`). The latter is not meant to e.g. hold onto any cryptocurrencies; it is simply a way of maintaining a secure communication channel between the device and your application.
+Once imported, you can instantiate your SDK client with a `clientConfig` object, which at minimum requires the name of your app (`name`) and a private key with which to sign requests (`privKey`). The latter is not meant to e.g. hold onto any cryptocurrencies; it is simply a way of maintaining a secure communication channel between the device and your application.
 
 ```
 const clientConfig = {
@@ -109,20 +109,19 @@ const cryptoLib = new ReactNativeCrypto(clientConfig.privKey);
 clientConfig.crypto = cryptoLib;
 ```
 
-### Initialize!
+### Instantiate
 
-With the `clientConfig` filled out, you can initialize a new SDK object:
+With the `clientConfig` filled out, you can instantiate a new SDK object:
 
 ```
 const client = new Client(clientConfig);
-client.initialize((err, connections) => { })
 ```
 
 This returns an array of connections to the providers you have specified.
 
 ## Connecting to a Lattice
 
-Once you have a client initialized, you can make a connection to any Lattice device which is connected to the internet:
+With the client object, you can make a connection to any Lattice device which is connected to the internet:
 
 ```
 const serial = 'MY_LATTICE';
@@ -910,18 +909,6 @@ This option may be deprecated. It currently only allows the user to pass `addres
 
 * `err` - string representing the error message (or `null`)
 * `res` - array of transaction objects (see `getTxHistory`)
-
-
-## initialize
-### (cb)
-
-Once the `client` object is created, you must initialize the providers. This establishes a connection to the desired networks through the providers.
-
-#### cb(err, connections)
-
-* `err` - string representing the error message (or `null`)
-* `connections` - array of connections to the desired networks. The format depends on the network and provider combination, but they should be non-empty for each provider.
-
 
 ## pair
 ### (appSecret, cb)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.0.16-development",
+  "version": "0.0.0-dev2-unstable",
   "description": "SDK to interact with GridPlus agent devices",
   "scripts": {
     "commit": "git-cz",

--- a/src/index.js
+++ b/src/index.js
@@ -146,51 +146,6 @@ export default class SdkClient {
     return this.providers[shortcode].getTx(hashes, cb, opts);
   }
 
-  initialize(options, cb) {
-    if (typeof options === 'function') {
-      cb = options;
-      options = {};
-    }
-
-    let shortcodes = [];
-
-    if ( ! options.shortcodes && options.shortcode) {
-      shortcodes = [ options.shortcode ];
-    }
-    else if (options.shortcodes) {
-      shortcodes = options.shortcodes;
-    } else {
-      shortcodes = Object.keys(this.providers);
-    }
-
-    if ( ! shortcodes.length) return cb(new Error('cannot initialize sdk. no providers specified'));
-
-    const promises = shortcodes.map(shortcode => {
-      return new Promise((resolve, reject) => {
-
-        const provider = this.providers[shortcode];
-
-        if ( ! provider) return reject(new Error(`no provider found with shortcode ${shortcode}`));
-
-        log(`initializing provider ${shortcode}`);
-
-        provider.initialize((err, info) => {
-          if (err) return reject(err);
-
-          this.providers[shortcode] = provider;
-
-          log(`initialized provider ${shortcode}`);
-          resolve(info);
-        });
-
-      });
-    });
-
-    return Promise.all(promises).then((info) => {
-      return cb(null, info);
-    }).catch(err => cb(err));
-  }
-
   pair(appSecret, cb) {
     return this.client.pair(appSecret, cb);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ export default class SdkClient {
       cb = serial;
       serial = null;
     }
-    return this.client.request('connect', cb);
+    return this.client._request({ method: 'connect' }, cb);
   }
 
   // Delete the pairing

--- a/src/providers/Bitcoin.js
+++ b/src/providers/Bitcoin.js
@@ -80,10 +80,6 @@ export default class Bitcoin {
     }, opts);
   }
 
-  initialize (cb) {
-    return this.provider.initialize(cb);
-  }
-
   _getChange(opts, utxos, value) {
     const feeRate = opts.perByteFee === undefined ? DEFAULT_FEE : opts.perByteFee;
     // Estimate the number of bytes of a transaction with (10 + 180*n_inputs + 32*n_outputs)

--- a/src/providers/Ethereum.js
+++ b/src/providers/Ethereum.js
@@ -90,10 +90,6 @@ export default class Ethereum {
     }
   }
 
-  initialize (cb) {
-    return cb(null, this.provider);
-  }
-
   getTxHistory(opts, cb) {
     this.provider.getTxHistory(opts)
     .then((history) => { return cb(null, history); })

--- a/src/providers/apis/bcoin.js
+++ b/src/providers/apis/bcoin.js
@@ -8,15 +8,6 @@ export default class BcoinApi {
     this.client = new NodeClient(opts);
   }
 
-  initialize(cb) {
-    this.client.getInfo()
-    .then((info) => {
-      if (!info || !info.network) return cb(new Error('Could not connect to node'));
-      return cb(null, info);
-    })
-    .catch((err) => cb(err))
-  }
-
   addBalanceMultiple(utxos, sat=true) {
     const d = {};
     Object.keys(utxos).forEach((u) => {

--- a/src/providers/apis/blockcypher.js
+++ b/src/providers/apis/blockcypher.js
@@ -38,12 +38,6 @@ export default class BlockCypherApi {
     }
   }
 
-  initialize(cb) {
-    return this._request(this.blockcypherBaseUrl)
-    .then((res) => { return cb(null, res); })
-    .catch((err) => cb(err));
-  }
-
   buildInputs(utxos, cb) {
     if (utxos.length === 0) {
       return cb(null, utxos);
@@ -257,7 +251,7 @@ export default class BlockCypherApi {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         if (body === null) {
-          return request.get(url)
+          return request.get(url).timeout(3000)
             .then((res) => { return resolve(res.body); })
             .catch((err) => { return reject(err); })
         } else {

--- a/test/btc-bcy.js
+++ b/test/btc-bcy.js
@@ -35,15 +35,6 @@ describe('Bitcoin via BlockCypher: transfers', () => {
     }) 
   })
 
-  it('Should connect to a BTC node provider', (done) => {
-    client.initialize((err, provider) => {
-      assert(err === null, err);
-      assert(typeof provider === 'object');
-      assert(provider[0].height > 0);
-      done();
-    });
-  });
-
   it('Should connect to an agent', (done) => {
     const serial = process.env.AGENT_SERIAL;
     client.connect(serial, (err, res) => {

--- a/test/btc-testnet3.js
+++ b/test/btc-testnet3.js
@@ -36,15 +36,6 @@
 //     }) 
 //   })
 
-//   it('Should connect to a BTC node provider', (done) => {
-//     client.initialize((err, provider) => {
-//       assert(err === null, err);
-//       assert(typeof provider === 'object');
-//       assert(provider[0].height > 0);
-//       setTimeout(() => { done() }, 750);
-//     });
-//   });
-
 //   it('Should connect to an agent', (done) => {
 //     const serial = process.env.AGENT_SERIAL;
 //     client.connect(serial, (err, res) => {

--- a/test/eth-rinkeby.js
+++ b/test/eth-rinkeby.js
@@ -6,7 +6,7 @@ import { Client, providers } from 'index';
 import NodeCrypto from 'gridplus-node-crypto';
 const TIMEOUT_SEC = 59;
 const { erc20Src } = require('./config.json');
-const { baseUrl, ethHolder, etherscanApiKey } = require('../secrets.json');
+const { baseUrl, ethHolder, etherscanApiKey, agent_serial } = require('../secrets.json');
 let client, addr, erc20Addr, sender, senderPriv, addr2, secrets;
 const transferAmount = 54;
 const providerOpts = {
@@ -29,17 +29,9 @@ describe('Ethereum via Etherscan: ether transfers', () => {
     console.log(4)
   });
 
-  it('Should connect to an ETH node', (done) => {
-    client.initialize((err, provider) => {
-      assert(err === null, err);
-      assert(typeof provider === 'object');
-      done();
-    })
-  });
-
   it('Should connect to an agent', (done) => {
-    const serial = process.env.AGENT_SERIAL;
-    client.connect(serial, (err, res) => {
+    // const serial = process.env.AGENT_SERIAL;
+    client.connect(agent_serial, (err, res) => {
       assert(err === null, err);
       assert(client.client.ecdhPub === res.key, 'Mismatched key on response')
       done()
@@ -95,6 +87,7 @@ describe('Ethereum via Etherscan: ether transfers', () => {
       value: toSend,
       data: '',
     };
+    console.log('Sending to address:', addr)
     client.providers.ETH.getNonce(tx.from)
     .then((nonce) => {
       tx.nonce = nonce;

--- a/test/local-btc.js
+++ b/test/local-btc.js
@@ -68,15 +68,6 @@ describe('Bitcoin', () => {
       privKey: crypto.randomBytes(32).toString('hex'),
       providers: [ btcProvider ]
     });
-
-  });
-
-  it('Should connect to a BTC node', (done) => {
-    client.initialize((err, connections) => {
-      assert.equal(err, null, err);
-      assert.equal(connections[0].network, 'regtest', 'Did not connect to testnet');
-      done();
-    })
   });
 
   it('Should check the balance of a single address and set a baseline', (done) => {

--- a/test/local-eth.js
+++ b/test/local-eth.js
@@ -29,17 +29,9 @@ describe('Ethereum', () => {
 
   });
 
-  it('Should connect to an ETH node', (done) => {
-    client.initialize((err, provider) => {
-      assert(err === null, err);
-      assert(typeof provider === 'object');
-      done();
-    })
-  });
-
   it('Should connect to an agent', (done) => {
-    const serial = process.env.AGENT_SERIAL;
-    client.connect(serial, (err, res) => {
+    // const serial = process.env.AGENT_SERIAL;
+    client.connect(secrets.serial, (err, res) => {
       assert(err === null, err);
       assert(client.client.ecdhPub === res.key, 'Mismatched key on response')
       done()
@@ -61,6 +53,7 @@ describe('Ethereum', () => {
       coin_type: '60\''
     }
     client.addresses(req, (err, addresses) => {
+      console.log('err', err, 'addr', addresses)
       assert(err === null, err);
       addr = addresses;
       client.getBalance('ETH', { address: addr }, (err, data) => {


### PR DESCRIPTION
The `initialize` function made it this far for legacy reasons, but we don't need it anymore. All it was doing is testing that the providers exists and, in the case of blockcypher, making an http request to the provider.

This can be removed from the API and the docs, as it is just an extraneous setup step plus additional friction.