### PR TITLE
Request ETH Transaction Signature

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -58,10 +58,15 @@ const responseCodes = {
     0x88: 'Device Error', 
 }
  
-
 const deviceResponses = {
     START_CODE_IDX: 1, // Beginning of 4-byte status code in Lattice response
     START_DATA_IDX: 5, // Beginning of data field for Lattice responses
+}
+
+const signingSchema = {
+    BTC_TRANSFER: 0,
+    ETH_TRANSFER: 1,
+    ERC20_TRANSFER: 2
 }
 
 const MAX_NUM_ADDRS = 10; // Maximum number of addresses we can request
@@ -80,6 +85,7 @@ module.exports = {
     messageConstants,
     responseCodes,
     deviceResponses,
+    signingSchema,
     MAX_NUM_ADDRS,
     REQUEST_TYPE_BYTE,
     VERSION_BYTE,

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,11 +2,16 @@
 const AES_IV = [0x6d, 0x79, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64]
 
 // Per Lattice spec, all encrypted messages must fit in a 272 byte buffer
-const ENC_MSG_LEN = 272;
-// Encrypted result length must be smaller than the message length. This is also
-// fixed across all encrypted responses. Note that it includes the ephem pubkey
-// which is 65 bytes, AND a 4 byte checksum
-const ENC_RES_LEN = 269; 
+const ENC_MSG_LEN = 544;
+
+// Decrypted response lengths will be fixed for any given message type.
+// These are defined in the Lattice spec.
+// Every decrypted response should have a 65-byte pubkey prefixing it
+const decResLengths = {
+    finalizePair: 0,   // Only contains the pubkey
+    getAddresses: 200, // 20-byte address * 10 max slots
+    sign: 74,          // Max DER signature length - THIS WILL CHANGE
+}
   
 const OPs = {
     'a9': 'OP_HASH160',
@@ -79,11 +84,11 @@ const VERSION_BYTE = 1;
 module.exports = {
     AES_IV,
     ENC_MSG_LEN,
-    ENC_RES_LEN,
     OPs,
     addressSizes,
     bitcoinVersionByte,
     currencyCodes,
+    decResLengths,
     deviceCodes,
     encReqCodes,
     messageConstants,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,12 @@
-
 // Consistent with Lattice's IV
 const AES_IV = [0x6d, 0x79, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x70, 0x61, 0x73, 0x73, 0x77, 0x6f, 0x72, 0x64]
 
 // Per Lattice spec, all encrypted messages must fit in a 272 byte buffer
 const ENC_MSG_LEN = 272;
+// Encrypted result length must be smaller than the message length. This is also
+// fixed across all encrypted responses. Note that it includes the ephem pubkey
+// which is 65 bytes, AND a 4 byte checksum
+const ENC_RES_LEN = 269; 
   
 const OPs = {
     'a9': 'OP_HASH160',
@@ -69,13 +72,14 @@ const signingSchema = {
     ERC20_TRANSFER: 2
 }
 
-const MAX_NUM_ADDRS = 10; // Maximum number of addresses we can request
+const ETH_DATA_MAX_SIZE = 100; // Maximum number of bytes that can go in the data field
 const REQUEST_TYPE_BYTE = 0x02; // For all HSM-bound requests
 const VERSION_BYTE = 1;
 
 module.exports = {
     AES_IV,
     ENC_MSG_LEN,
+    ENC_RES_LEN,
     OPs,
     addressSizes,
     bitcoinVersionByte,
@@ -86,7 +90,7 @@ module.exports = {
     responseCodes,
     deviceResponses,
     signingSchema,
-    MAX_NUM_ADDRS,
+    ETH_DATA_MAX_SIZE,
     REQUEST_TYPE_BYTE,
     VERSION_BYTE,
 }

--- a/test/connect-and-pair.js
+++ b/test/connect-and-pair.js
@@ -44,6 +44,14 @@ describe('Connect and Pair', () => {
     })
   }
 
+  function sign(client, opts) {
+    return new Promise((resolve, reject) => {
+      client.sign((res) => {
+        return resolve(res);
+      })
+    })
+  }
+
   it('Should connect to an agent', async () => {
     // const _id = question('Please enter the ID of your test device: ');
     // id = _id;
@@ -111,7 +119,14 @@ describe('Connect and Pair', () => {
       addrData.n = 11;
       addrs = await getAddresses(client, addrData);
       expect(addrs.err).to.not.equal(null);
+      
     }
   });
+
+  it('Should sign a tx (dummy)', async () => {
+    const sig = await sign(client, {});
+    expect(sig.err).to.equal(null);
+  })
+  
 
 });

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -84,12 +84,54 @@ describe('Connect and Pair', () => {
     }
   });
 
+  it('Should get addresses', async () => {
+    expect(caughtErr).to.equal(false);
+    if (caughtErr == false) {
+      const addrData = { currency: 'BTC', startIndex: 1000, n: 5 }
+      // Legacy addresses (default `version`)
+      let addrs = await getAddresses(client, addrData);
+      expect(addrs.err).to.equal(null);
+      expect(addrs.data.length).to.equal(5);
+      expect(addrs.data[0][0]).to.equal('1');
+      
+      // P2SH addresses
+      addrData.version = 'P2SH';
+      addrData.n = 4;
+      addrs = await getAddresses(client, addrData);
+      expect(addrs.err).to.equal(null);
+      expect(addrs.data.length).to.equal(4);
+      expect(addrs.data[0][0]).to.equal('3');
+      // Ethereum addresses
+      addrData.currency = 'ETH';
+      addrs = await getAddresses(client, addrData);
+      expect(addrs.err).to.equal(null);
+      expect(addrs.data.length).to.equal(4);
+      expect(addrs.data[0].slice(0, 2)).to.equal('0x');
+      // Failure cases
+      // Unsupported currency
+      addrData.currency = 'BCH';
+      addrs = await getAddresses(client, addrData);
+      expect(addrs.err).to.not.equal(null);
+      // Unsupported version byte
+      addrData.currency = 'BTC';
+      addrData.version = 'P2WKH';
+      addrs = await getAddresses(client, addrData);      
+      expect(addrs.err).to.not.equal(null);
+      // Too many addresses (n>10)
+      addrData.version = 'P2SH';
+      addrData.n = 11;
+      addrs = await getAddresses(client, addrData);
+      expect(addrs.err).to.not.equal(null);
+      
+    }
+  });
+
   it('Should sign Ethereum transactions', async () => {
     // Constants from firmware
     const GAS_PRICE_MAX = 100000000000;
     const GAS_LIMIT_MIN = 22000;
     const GAS_LIMIT_MAX = 10000000;
-
+    
     let txData = {
       nonce: 5,
       gasPrice: 1200000000,
@@ -107,7 +149,7 @@ describe('Connect and Pair', () => {
     }
     // [TODO] Add signature verification mechanism once
     // signatures map directly to derived addresses
-
+    
     // Sign a legit tx
     let sig = await sign(client, req);
     expect(sig.err).to.equal(null);
@@ -166,47 +208,7 @@ describe('Connect and Pair', () => {
     req.data.txData.data = crypto.randomBytes(constants.ETH_DATA_MAX_SIZE).toString('hex');
     sig = await sign(client, req);
     expect(sig.err).to.equal(null);
- 
-  })
-/*
-  it('Should get addresses', async () => {
-    expect(caughtErr).to.equal(false);
-    if (caughtErr == false) {
-      const addrData = { currency: 'BTC', startIndex: 1000, n: 5 }
-      // Legacy addresses (default `version`)
-      let addrs = await getAddresses(client, addrData);
-      expect(addrs.err).to.equal(null);
-      expect(addrs.data.length).to.equal(5);
-      expect(addrs.data[0][0]).to.equal('1');
-      // P2SH addresses
-      addrData.version = 'P2SH';
-      addrData.n = 4;
-      addrs = await getAddresses(client, addrData);
-      expect(addrs.err).to.equal(null);
-      expect(addrs.data.length).to.equal(4);
-      expect(addrs.data[0][0]).to.equal('3');
-      // Ethereum addresses
-      addrData.currency = 'ETH';
-      addrs = await getAddresses(client, addrData);
-      expect(addrs.err).to.equal(null);
-      expect(addrs.data.length).to.equal(4);
-      expect(addrs.data[0].slice(0, 2)).to.equal('0x');
-      // Failure cases
-      // Unsupported currency
-      addrData.currency = 'BCH';
-      addrs = await getAddresses(client, addrData);
-      expect(addrs.err).to.not.equal(null);
-      // Unsupported version byte
-      addrData.currency = 'BTC';
-      addrData.version = 'P2WKH';
-      addrs = await getAddresses(client, addrData);      
-      expect(addrs.err).to.not.equal(null);
-      // Too many addresses (n>10)
-      addrData.version = 'P2SH';
-      addrData.n = 11;
-      addrs = await getAddresses(client, addrData);
-      expect(addrs.err).to.not.equal(null);
-    }
+    
   });
-*/
+
 });


### PR DESCRIPTION
This PR adds the ability to request a signature on an RLP-encoded Ethereum transaction. The Lattice will respond with an error if the message is invalid or the user rejects the request. It will return a DER-encoded signature if the request is authorized.

NOTE: `sign` is not yet production-ready, as it does not include Bitcoin transaction requests.