### PR TITLE
Add get wallets path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
 # GridPlus SDK
 
-**WARNING: This is beta software and may contain bugs. Please limit cryptocurrency-related use to small amounts.**
-
 The [GridPlus SDK](https://github.com/GridPlus/gridplus-sdk) allows any application to establish a connection and interact with a GridPlus Lattice device. 
 
 # Installation
@@ -59,33 +57,41 @@ With the client object, you can make a connection to any Lattice device which is
 
 ```
 const deviceId = 'MY_LATTICE';
-client.connect(deviceId, (err) => {
+client.connect(deviceId, (err, isPaired) => {
     ...
 });
 ```
 
-If you get a non-error response, it means you can talk to the device. 
+If you get a non-error response, it means you can talk to the device. Note that the response also tells you whether you are paired with the device.
 
-*NOTE: The `deviceId` is listed on your Lattice under `Settings->Device Info`*
+> The `deviceId` is listed on your Lattice under `Settings->Device Info`
 
 # Pairing with a Lattice
+
+> This function requires the user to interact with the Lattice. It therefore uses your client's timeout to sever the request if needed.
 
 When `connect` is called, your Lattice will draw a random, six digit secret on the screen. The SDK uses
 this to "pair" with the device:
 
 ```
-client.pair('SECRET', (err) => {
+client.pair('SECRET', (err, hasActiveWallet) => {
     ...
 });
 ```
 
-*NOTE: This function requires the user to interact with the Lattice. It therefore uses your client's timeout to sever the request if needed.*
+A non-error response indicates you may now make encrypted requests. 
+
+> If `hasActiveWallet = false`, it means there was an error fetching the current wallet on the device. This could mean the device has not been set up
+or that a SafeCard is inserted which has not been set up. It could also mean there was an error with the connection. If you try to get addresses or sign without
+an active wallet saved (it is saved automatically if `hasActiveWallet = true`), the SDK will automatically retry fetching the active wallet before making the
+original request.
 
 # Getting Addresses
 
-You may retrieve some number of addresses for supported cryptocurrencies. The Lattice uses [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)-compliant highly-deterministic (HD) wallets for generating addresses. You may request a set of contiguous addresses (e.g. indices 5 to 10 or 33 to 36) based on a currency (`ETH` or `BTC`).
+> If the SDK is connected to the wrong wallet or if the device has no current active wallet, this request will take additional time to complete.
 
-> NOTE: For now, you may only request a maximum of 10 addresses at a time from the Lattice per request
+You may retrieve some number of addresses for supported cryptocurrencies. The Lattice uses [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)-compliant highly-deterministic (HD) wallets for generating addresses. You may request a set of contiguous addresses (e.g. indices 5 to 10 or 33 to 36) based on a currency (`ETH` or `BTC`). *For now, you may only request a maximum of 10 addresses at a time from the Lattice per request.*
+
 
 An example request looks like:
 
@@ -112,6 +118,9 @@ client.addresses(req, (err, res) => {
 
 
 # Requesting Signatures
+
+> This function requires the user to interact with the Lattice. It therefore uses your client's timeout to sever the request if needed.
+> If the SDK is connected to the wrong wallet or if the device has no current active wallet, this request will take additional time to complete.
 
 The Lattice device, at its core, is a tightly controlled, highly configurable, cryptographic signing machine. By default, each pairing (the persistent association between your app and a user's lattice) allows the app an ability to request signatures that the user must manually authorize.
 

--- a/src/client.js
+++ b/src/client.js
@@ -21,7 +21,6 @@ const {
   encReqCodes,
   responseCodes,
   deviceResponses,
-  GET_WALLETS_NUM,
   REQUEST_TYPE_BYTE,
   VERSION_BYTE,
   messageConstants,
@@ -107,7 +106,7 @@ class Client {
         // be encountered later when getting addresses or making a signature, as
         // they are typically downstream in most workflows.
         return cb(null, this.hasActiveWallet());
-      }));
+      });
     })  
   }
 
@@ -442,7 +441,7 @@ class Client {
     let off = 65; // Skip past pubkey prefix
     const res = decrypted.data;
     let walletUID, isPresent, name;
-    for (let i = 0; i < GET_WALLETS_NUM; i++) {
+    for (let i = 0; i < 2; i++) { // loop through internal and external wallet data
       walletUID = res.slice(off, off+32); off += 32;
       isPresent = Boolean(res[off]); off++;
       name = res.slice(off, off+20); off += 20;

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,8 +7,8 @@ const AES_IV = [0x6d, 0x79, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x70, 0x61, 0x73
 const decResLengths = {
     finalizePair: 0,   // Only contains the pubkey
     getAddresses: 200, // 20-byte address * 10 max slots
-    sign: 1090,          // 1 DER signature for ETH, 10 for BTC (not all are used for BTC)
-    getWallets: 112,  // 56 bytes per wallet record (response contains internal and external)   
+    sign: 1090,        // 1 DER signature for ETH, 10 for BTC (not all are used for BTC)
+    getWallets: 142,   // 71 bytes per wallet record (response contains internal and external)   
 }
 
 // Per Lattice spec, all encrypted messages must fit in a buffer of this size.

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,7 @@ const decResLengths = {
     finalizePair: 0,   // Only contains the pubkey
     getAddresses: 200, // 20-byte address * 10 max slots
     sign: 1090,          // 1 DER signature for ETH, 10 for BTC (not all are used for BTC)
-    getWallets: 53 * GET_WALLETS_NUM,  // 53 bytes per wallet record     
+    getWallets: 112,  // 56 bytes per wallet record (response contains internal and external)   
 }
 
 // Per Lattice spec, all encrypted messages must fit in a buffer of this size.
@@ -73,7 +73,6 @@ const signingSchema = {
 const ETH_DATA_MAX_SIZE = 100; // Maximum number of bytes that can go in the data field
 const REQUEST_TYPE_BYTE = 0x02; // For all HSM-bound requests
 const VERSION_BYTE = 1;
-const GET_WALLETS_NUM = 10;
 
 const BASE_URL = 'https://signing.gridpl.us';
 
@@ -91,7 +90,6 @@ module.exports = {
     deviceResponses,
     signingSchema,
     ETH_DATA_MAX_SIZE,
-    GET_WALLETS_NUM,
     REQUEST_TYPE_BYTE,
     VERSION_BYTE,
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -55,12 +55,13 @@ const responseCodes = {
     0x86: 'Pairing is Currently Disabled',
     0x87: 'Automated Signing is Currently Disabled',
     0x88: 'Device Error', 
-    0x90: 'No active wallet found',
+    0x90: 'Incorrect Wallet UID Provided',
 }
  
 const deviceResponses = {
     START_CODE_IDX: 1, // Beginning of 4-byte status code in Lattice response
     START_DATA_IDX: 5, // Beginning of data field for Lattice responses
+    ERR_WRONG_WALLET_UID: 0x90,
 }
 
 const signingSchema = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,8 @@ const AES_IV = [0x6d, 0x79, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, 0x70, 0x61, 0x73
 const decResLengths = {
     finalizePair: 0,   // Only contains the pubkey
     getAddresses: 200, // 20-byte address * 10 max slots
-    sign: 1090,          // 1 DER signature for ETH, 10 for BTC (not all are used for BTC)       
+    sign: 1090,          // 1 DER signature for ETH, 10 for BTC (not all are used for BTC)
+    getWallets: 53 * GET_WALLETS_NUM,  // 53 bytes per wallet record     
 }
 
 // Per Lattice spec, all encrypted messages must fit in a buffer of this size.
@@ -21,10 +22,11 @@ const deviceCodes = {
 }
 
 const encReqCodes = {
-    'FINALIZE_PAIRING': 0,
-    'GET_ADDRESSES': 1,
-    'ADD_PERMISSION': 2,
-    'SIGN_TRANSACTION': 3,
+    'FINALIZE_PAIRING': 0x00,
+    'GET_ADDRESSES': 0x01,
+    'ADD_PERMISSION': 0x02,
+    'SIGN_TRANSACTION': 0x03,
+    'GET_WALLETS': 0x04,
 }
 
 const messageConstants = {
@@ -69,6 +71,7 @@ const signingSchema = {
 const ETH_DATA_MAX_SIZE = 100; // Maximum number of bytes that can go in the data field
 const REQUEST_TYPE_BYTE = 0x02; // For all HSM-bound requests
 const VERSION_BYTE = 1;
+const GET_WALLETS_NUM = 10;
 
 const BASE_URL = 'https://signing.gridpl.us';
 
@@ -86,6 +89,7 @@ module.exports = {
     deviceResponses,
     signingSchema,
     ETH_DATA_MAX_SIZE,
+    GET_WALLETS_NUM,
     REQUEST_TYPE_BYTE,
     VERSION_BYTE,
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -55,6 +55,7 @@ const responseCodes = {
     0x86: 'Pairing is Currently Disabled',
     0x87: 'Automated Signing is Currently Disabled',
     0x88: 'Device Error', 
+    0x90: 'No active wallet found',
 }
  
 const deviceResponses = {

--- a/src/util.js
+++ b/src/util.js
@@ -46,6 +46,7 @@ function parseLattice1Response(r) {
   const responseCode = payload.readUInt8(0);
   if (responseCode !== responseCodes.SUCCESS) {
     parsed.err = `Error from device: ${responseCodes[responseCode] ? responseCodes[responseCode] : 'Unknown Error'}`;
+    parsed.responseCode = responseCode;
     return parsed;
   } else {
     parsed.data = payload.slice(1, payload.length);

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -13,7 +13,7 @@ describe('Connect and Pair', () => {
   before(() => {
     client = new Sdk.Client({
       name: 'ConnectAndPairClient',
-      // baseUrl: 'https://signing.staging-gridpl.us'
+      baseUrl: 'https://signing.staging-gridpl.us',
       crypto,
       timeout: 120000,
     });
@@ -81,7 +81,7 @@ describe('Connect and Pair', () => {
       expect(client.isPaired).to.equal(true);
     }
   });
-
+/*
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);
     if (caughtErr == false) {
@@ -338,5 +338,5 @@ describe('Connect and Pair', () => {
     expect(sigResp.tx).to.not.equal(null);
     expect(sigResp.txHash).to.not.equal(null);
   });
-
+*/
 });

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -4,16 +4,18 @@ const expect = require('chai').expect;
 const Sdk = require('../index.js');
 const crypto = require('crypto');
 const question = require('readline-sync').question;
-
+const Buffer = require('buffer/').Buffer;
 let client, rl, id;
 let caughtErr = false;
+const EMPTY_WALLET_UID = Buffer.alloc(32);
 
 describe('Connect and Pair', () => {
 
   before(() => {
     client = new Sdk.Client({
-      name: 'ConnectAndPairClient',
+      name: 'SDK Test',
       baseUrl: 'https://signing.staging-gridpl.us',
+      // privKey: Buffer.from('3fb53b677f73e4d2b8c89c303f6f6b349f0075ad88ea126cb9f6632085815dca', 'hex'),
       crypto,
       timeout: 120000,
     });
@@ -60,7 +62,9 @@ describe('Connect and Pair', () => {
     caughtErr = connectErr !== null;
     expect(connectErr).to.equal(null);
     expect(client.isPaired).to.equal(false);
+    expect(client.activeWallet.uid.equals(EMPTY_WALLET_UID)).to.equal(true);
   });
+
 
   it('Should attempt to pair with pairing secret', async () => {
     expect(caughtErr).to.equal(false);
@@ -69,6 +73,7 @@ describe('Connect and Pair', () => {
       const pairErr = await pair(client, secret);
       caughtErr = pairErr !== null;
       expect(pairErr).to.equal(null);
+      expect(client.activeWallet.uid.equals(EMPTY_WALLET_UID)).to.equal(false);
     }
   });
 
@@ -79,8 +84,10 @@ describe('Connect and Pair', () => {
       caughtErr = connectErr !== null;
       expect(connectErr).to.equal(null);
       expect(client.isPaired).to.equal(true);
+      expect(client.activeWallet.uid.equals(EMPTY_WALLET_UID)).to.equal(false);
     }
   });
+
 /*
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);


### PR DESCRIPTION
Adds path to get active wallets (`getWallets`) and uses this in encrypted requests. (#69)

Rules:

* After `connect`, if we are paired, call `getWallets` and callback `(err, isPaired)`
* After `finalizePairing`, call `getWallets` and callback `(null, hasActiveWallet)` -- note that we bypass `getWallets` errors after finalizing the pairing! This is because it is upstream of later requests, which do capture such errors
* If `getAddresses` or `pair` returns an error indicating we have provided the wrong wallet UID, call `getWallets` and recursively call the original route with the active wallet now saved. If `getWallets` encountered an error here, pass it back and cancel the original request.