### PR TITLE
Use both wallet uids

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -239,3 +239,31 @@ The returned `signedTx` object has the following properties:
 | ETH / BTC | `tx`              | string  | Ready-to-broadcast, serialized transaction + signature payload |
 | ETH / BTC | `txHash`          | string  | Hash of the transaction for lookup on the relevant block explorer |
 | BTC       | `changeRecipient` | string  | Lattice wallet address that recieved the BTC change |
+
+
+# Getting Active Wallets
+
+The Lattice1 has two wallet "slots": an internal wallet that is always the same for a given device and an external slot for SafeCard wallets. When a SafeCard is
+inserted or removed, the external slot is updated. If a wallet is present in a given slot, the device will allow paired requesters to get the "wallet UID", against
+which addresses or signatures may be requested. This UID is a permanent identifier for a given wallet (i.e. every SafeCard, once setup, will have a permanent UID
+that maps directly to a wallet seed and, therefore, to a set of addresses).
+
+Although these requests are abstracted from the user of this SDK, you may look at the active wallets currently known by the SDK. This may be useful for determining
+if there is a SafeCard inserted.
+
+```
+const wallet = client.getActiveWallet();
+```
+
+This will return an object containing:
+
+```
+uid           // 32 byte buffer id
+name          // 20 char (max) string
+capabilities  // 4 byte flag
+external      // boolean
+```
+
+Where `uid` is a 32-byte buffer containing the wallet UID discussed above and `external` is `true` if the active wallet is a SafeCard.
+**NOTE: If a SafeCard is inserted, this will be the data returned from `getActiveWallet()`. When it is removed, you will get the internal wallet data. 
+Currently, `name` and `capabilities` are not used.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.2.0-dev",
+  "version": "0.2.1-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.2.1-dev",
+  "version": "0.2.2-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/client.js
+++ b/src/client.js
@@ -435,25 +435,27 @@ class Client {
     const walletDescriptorLen = 71;
     // Skip 65byte pubkey prefix. WalletDescriptor contains 32byte id + 4byte flag + 35byte name
     let off = 65;
+
     // Internal first
     let hasActiveWallet = false;
     walletUID = res.slice(off, off+32);
-    if (!walletUID.equals(EMPTY_WALLET_UID)) {
-      this.activeWallets.internal.uid = walletUID;
-      this.activeWallets.internal.capabilities = res.readUInt32BE(off+32);
-      this.activeWallets.internal.name = res.slice(off+36, off+walletDescriptorLen);
+    this.activeWallets.internal.uid = walletUID;
+    this.activeWallets.internal.capabilities = res.readUInt32BE(off+32);
+    this.activeWallets.internal.name = res.slice(off+36, off+walletDescriptorLen);
+    if (!walletUID.equals(EMPTY_WALLET_UID))
       hasActiveWallet = true;
-    }
+
     // Offset the first item
     off += walletDescriptorLen;
+    
     // External
     walletUID = res.slice(off, off+32);
-    if (!walletUID.equals(EMPTY_WALLET_UID)) {
-      this.activeWallets.external.uid = walletUID;
-      this.activeWallets.external.capabilities = res.readUInt32BE(off+32);
-      this.activeWallets.external.name = res.slice(off+36, off+walletDescriptorLen);
+    this.activeWallets.external.uid = walletUID;
+    this.activeWallets.external.capabilities = res.readUInt32BE(off+32);
+    this.activeWallets.external.name = res.slice(off+36, off+walletDescriptorLen);
+    if (!walletUID.equals(EMPTY_WALLET_UID))
       hasActiveWallet = true;
-    }
+
     if (hasActiveWallet === true)
       return null;
     else

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -65,7 +65,7 @@ describe('Connect and Pair', () => {
     caughtErr = connectErr !== null;
     expect(connectErr).to.equal(null);
     expect(client.isPaired).to.equal(false);
-    expect(client.activeWallet.uid.equals(EMPTY_WALLET_UID)).to.equal(true);
+    expect(client.hasActiveWallet()).to.equal(false);
   });
 
 
@@ -76,7 +76,7 @@ describe('Connect and Pair', () => {
       const pairErr = await pair(client, secret);
       caughtErr = pairErr !== null;
       expect(pairErr).to.equal(null);
-      expect(client.activeWallet.uid.equals(EMPTY_WALLET_UID)).to.equal(false);
+      expect(client.hasActiveWallet()).to.equal(true);
     }
   });
 
@@ -87,7 +87,7 @@ describe('Connect and Pair', () => {
       caughtErr = connectErr !== null;
       expect(connectErr).to.equal(null);
       expect(client.isPaired).to.equal(true);
-      expect(client.activeWallet.uid.equals(EMPTY_WALLET_UID)).to.equal(false);
+      expect(client.hasActiveWallet()).to.equal(true);
     }
   });
 
@@ -114,9 +114,17 @@ describe('Connect and Pair', () => {
       addrData.n = 1;
       addrs = await getAddresses(client, addrData, 2000);
       expect(addrs.length).to.equal(1);
-      // expect(addrs[0].slice(0, 2)).to.equal('0x');
+      expect(addrs[0].slice(0, 2)).to.equal('0x');
       addrData.startPath[1] = HARDENED_OFFSET; // Back to BTC
       addrData.n = 5;
+
+      // Bitcoin testnet
+      // addrData.startPath[1] = HARDENED_OFFSET + 1; // BTC_TEST
+      // addrs = await getAddresses(client, addrData, 2000);
+      // console.log('testnet', addrs)
+      // expect(addrs.length).to.equal(5);
+      // expect(addrs[0][0]).to.be.oneOf(["n", "m", "2"]);
+      // addrData.startPath[1] = HARDENED_OFFSET; // Back to BTC
 
       // Failure cases
       // Unsupported purpose (m/<purpose>/)


### PR DESCRIPTION
This PR updates the SDK memory store to hold both active wallets (internal and external) and to utilize the higher priority one (external wallet is higher priority than internal)