### PR TITLE
ETH transaction fields: use big endian

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.3.0-dev",
+  "version": "0.3.1-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/client.js
+++ b/src/client.js
@@ -173,8 +173,9 @@ class Client {
     // so that checksums may be validated. The full size is 1266 bytes,
     // but that includes a 1-byte prefix (`SIGN_TRANSACTION`), 2 bytes
     // indicating the schema type, and 4 bytes for a checksum.
-    // Therefore, the payload itself has 1273 - 7 = 1266 bytes of space.
-    const MAX_TX_REQ_DATA_SIZE = 1266;
+    // Therefore, the payload itself has 1224 - 7 = 1217 bytes of space.
+    const MAX_TX_REQ_DATA_SIZE = 1152;
+
     if (tx.payload.length > MAX_TX_REQ_DATA_SIZE) {
       return cb('Transaction is too large');
     }


### PR DESCRIPTION
Updates ETH transactions to use fields with big endian values, as per new messaging spec and firmware.