### PR TITLE
Fixes bug in handling BTC signing responses with multiple sigs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.3.2-dev",
+  "version": "0.3.3-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",


### PR DESCRIPTION
We were not properly counting the offset before, which resulted in
empty pubkeys. This is now fixed.