### PR TITLE
Adds 1-byte padding when needed on shared secret

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.4.3-dev",
+  "version": "0.4.4-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/client.js
+++ b/src/client.js
@@ -254,7 +254,13 @@ class Client {
   // and the ephemeral public key
   // @returns Buffer
   _getSharedSecret() {
-    return Buffer.from(this.key.derive(this.ephemeralPub.getPublic()).toArray());
+    const secret = Buffer.from(this.key.derive(this.ephemeralPub.getPublic()).toArray());
+    // Once every ~256 attempts, we will get a key that starts with a `00` byte, which
+    // `elliptic` drops. This leads to problems initializing AES
+    if (secret.length === 31)
+      return Buffer.concat([Buffer.alloc(1), secret])
+    else
+      return secret;
   }
 
   // Get the ephemeral id, which is the first 4 bytes of the shared secret


### PR DESCRIPTION
Every 1 in ~256 encrypted requests results in a shared secret whose
first byte is `00`, which is removed by `elliptic` when doing the
ECDH derivation. An error is then thrown when initializing AES
with a 31-byte secret/private key.
This left-pads the shared secret buffer when elliptic gives us a
32-byte secret.

Fixes #78