### PR TITLE
Better fix for forcing 32 byte shared secrets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.4.5-dev",
+  "version": "0.4.6-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.4.4-dev",
+  "version": "0.4.5-dev",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/client.js
+++ b/src/client.js
@@ -254,13 +254,9 @@ class Client {
   // and the ephemeral public key
   // @returns Buffer
   _getSharedSecret() {
-    const secret = Buffer.from(this.key.derive(this.ephemeralPub.getPublic()).toArray());
     // Once every ~256 attempts, we will get a key that starts with a `00` byte, which
-    // `elliptic` drops. This leads to problems initializing AES
-    if (secret.length === 31)
-      return Buffer.concat([Buffer.alloc(1), secret])
-    else
-      return secret;
+    // can lead to problems initializing AES if we don't force a 32 byte BE buffer.
+    Buffer.from(this.key.derive(this.ephemeralPub.getPublic()).toArray('be', 32));
   }
 
   // Get the ephemeral id, which is the first 4 bytes of the shared secret

--- a/src/client.js
+++ b/src/client.js
@@ -256,7 +256,7 @@ class Client {
   _getSharedSecret() {
     // Once every ~256 attempts, we will get a key that starts with a `00` byte, which
     // can lead to problems initializing AES if we don't force a 32 byte BE buffer.
-    Buffer.from(this.key.derive(this.ephemeralPub.getPublic()).toArray('be', 32));
+    return Buffer.from(this.key.derive(this.ephemeralPub.getPublic()).toArray('be', 32));
   }
 
   // Get the ephemeral id, which is the first 4 bytes of the shared secret


### PR DESCRIPTION
This fix uses bn.js' underlying `.toArray` function in order
to force a 32 byte, big endian shared secret.

Fixes #83