### PR TITLE
Updates ETH tests to better test new display capability

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -177,7 +177,7 @@ const signOpts = {
 | `gasLimit` | number    | Must be >=22000    |
 | `gasPrice` | number    | Must be >0         |
 | `to`       | string    | Must be 20 bytes (excluding optional `0x` prefix) |
-| `value`    | number    | None               |
+| `value`    | number or hex string    | None               |
 | `data`     | string    | Must be <557 bytes |
 | `signerPath`| Array | Address path from which to sign this transaction. NOTE: Ethereum wallets typically use the path specified in the example above for all transactions. |
 | `chainId`  | string/number    | Name of the chain to use, options provided below. If a number is passed, it will use that. |

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -177,20 +177,18 @@ if (!process.env.skip) {
 
     it('Should test range of `value`', async () => {
       const txData = JSON.parse(JSON.stringify(defaultTxData))
-      
-      // Expected passes
-      txData.value = 100;
-      await testTxPass(buildTxReq(txData))  
-      txData.value = 10**18;
+      txData.value = 1;
+      await testTxPass(buildTxReq(txData))
+      txData.value = 1234;
+      await testTxPass(buildTxReq(txData))
+      txData.value = 10**14;
       await testTxPass(buildTxReq(txData))
       txData.value = 10**64;
       await testTxPass(buildTxReq(txData))
       txData.value = 10**77;
       await testTxPass(buildTxReq(txData))
-      
-      // Expected failures
-      txData.value = 10**78;
-      await testTxFail(buildTxReq(txData))
+      txData.value = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      await testTxPass(buildTxReq(txData))
     });
 
     it('Should test the range of `data`', async () => {


### PR DESCRIPTION
We no longer restrict value based on the display constraints on the Lattice,
i.e. we now support displays as low as 1 wei and as high as the largest u256.

### Do not merge until v0.9.8 is released in Lattice firmware