### PR TITLE
Fixes bug in displaying UFT8, non-ASCII personalSign messages

### DIFF
--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -32,7 +32,7 @@ exports.buildEthereumMsgRequest = function(input) {
     if (typeof input.payload === 'string') {
       if (input.payload.slice(0, 2) === '0x') {
         payload = ensureHexBuffer(input.payload)
-        displayHex = false === isASCII(payload.toString());
+        displayHex = true === isHexStr(input.payload.slice(2));
       } else {
         payload = Buffer.from(input.payload)
       }
@@ -314,8 +314,8 @@ function writeUInt64BE(n, buf, off) {
   return preBuf;
 }
 
-function isASCII(str) {
-    return (/^[\x00-\x7F]*$/).test(str)
+function isHexStr(str) {
+  return (/^[0-9a-fA-F]+$/).test(str)
 }
 
 const chainIds = {


### PR DESCRIPTION
We now check if the string is a hex string, rather than an ASCII string.
This allows us to still print utf8 strings even if the characters are
non-ascii.

Note that this will not display non-ascii characters now, but it will display the ascii parts of the utf8 message. Display of the characters themselves in scope of firmware, not the SDK.