### PR TITLE
Add mechanism to block personal_sign requests with non-ASCII characters.

### DIFF
--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -34,6 +34,8 @@ exports.buildEthereumMsgRequest = function(input) {
         payload = ensureHexBuffer(input.payload)
         displayHex = true === isHexStr(input.payload.slice(2));
       } else {
+        if (false === latticeCanDisplayStr(input.payload))
+          throw new Error('Currently, the Lattice can only display ASCII strings.');
         payload = Buffer.from(input.payload)
       }
     } else if (typeof input.displayHex === 'boolean') {
@@ -316,6 +318,16 @@ function writeUInt64BE(n, buf, off) {
 
 function isHexStr(str) {
   return (/^[0-9a-fA-F]+$/).test(str)
+}
+
+// Determine if the Lattice can display a string we give it. Currently, the Lattice can only
+// display ASCII strings, so we will reject other UTF8 codes.
+// In the future we may add a mechanism to display certain UTF8 codes such as popular emojis.
+function latticeCanDisplayStr(str) {
+  for (let i = 0; i < str.length; i++)
+    if (str.charCodeAt(i) < 0x0020 || str.charCodeAt(i) > 0x007f)
+      return false;
+  return true;
 }
 
 const chainIds = {

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -418,7 +418,7 @@ describe('Test random transaction data', function() {
   })
 })
 
-describe('Test random ETH messages', function() {
+describe('Test ETH personalSign', function() {
   beforeEach(() => {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');
   })
@@ -432,6 +432,14 @@ describe('Test random ETH messages', function() {
     } catch (err) {
       setTimeout(() => { next(err) }, 2500);
     }
+  })
+
+  it('Should throw error when message contains non-ASCII characters', async () => {
+    const protocol = 'signPersonal';
+    const msg = '⚠️';
+    const msg2 = 'ASCII plus ⚠️';
+    await testMsg(buildMsgReq(msg, protocol), false);
+    await testMsg(buildMsgReq(msg2, protocol), false);
   })
 
   it('Msg: sign_personal boundary conditions', async () => {


### PR DESCRIPTION
Unfortunately, we cannot currently display anything other than ASCII on the Lattice.
We may add support for common emojis or other characters, so this commit adds a
function to whitelist UTF8 character codes (currently only ASCII is whitelisted).

Resolves #112 