### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",


### PR DESCRIPTION
Changelog (relative to [`0.6.1`](https://github.com/GridPlus/gridplus-sdk/releases/tag/v0.6.1)):

* #106: Update docs to include `ETH_MSG` requests. Currently we only support `personal_sign`, but we will add EIP712 at some point.
* #108: Adds support for larger chainIDs. Previously we only allowed 1 byte for a chainID, capping the maximum at 255. Now we support chainIDs up to 32 bytes (i.e. a u256). The chainID is now included in the `data` buffer and it can be any size between 0 (for chainID < 255) and 32 bytes (for chainID = `UINT256_MAX`). These changes are supported in Lattice firmware versions 0.9.8 and above.
* #110: Updates ETH integration tests. This corresponds to a change in Lattice firmware (0.9.8 and above) in how we display ETH `value`s. We now support display of up to `UINT256_MAX` for the `value` portion of an ETH transaction.
* #111: Fixes bug in displaying UTF8 `personal_sign` messages. Before we were treating every non-ASCII request as a hex string but now we default to a UTF8 interpretation.
* #113: Follow up to #111, which was leading to incorrectly displayed data. This adds a whitelist of characters that can be displayed by the Lattice. 