### PR TITLE
Using Lattice firmware version

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -490,7 +490,7 @@ class Client {
     const pub = res.slice(off, off + 65).toString('hex'); off += 65;
     // Grab the firmware version (will be 0-length for older fw versions)
     // It is of format |fix|minor|major|reserved|
-    this.fwVersion = res.slice(off);
+    this.fwVersion = res.slice(off, off + 4);
     // Set the public key
     this.ephemeralPub = getP256KeyPairFromPub(pub);
     // return the state of our pairing

--- a/src/client.js
+++ b/src/client.js
@@ -16,6 +16,7 @@ const {
   toPaddedDER,
 } = require('./util');
 const {
+  getFwVersionConst,
   ADDR_STR_LEN,
   ENC_MSG_LEN,
   decResLengths,
@@ -198,21 +199,24 @@ class Client {
       return cb('Unsupported currency');
     }
 
+    // All transaction requests must be put into the same sized buffer.
+    // This comes from sizeof(GpTransactionRequest_t), but note we remove
+    // the 2-byte schemaId since it is not returned from our resolver.
+    // Note that different firmware versions may have different data sizes.
+    const fwConstants = getFwVersionConst(this.fwVersion);
+
     // Build the signing request payload to send to the device. If we catch
     // bad params, return an error instead
+    data.ethMaxDataSz = fwConstants.ethMaxDataSz;
+    data.ethMaxMsgSz = fwConstants.ethMaxMsgSz;
     const req = signReqResolver[currency](data);
     if (req.err !== undefined) return cb({ err: req.err });
-    // All transaction requests must be put into the same sized buffer
-    // so that checksums may be validated. The full size is 1266 bytes,
-    // but that includes a 1-byte prefix (`SIGN_TRANSACTION`), 2 bytes
-    // indicating the schema type, and 4 bytes for a checksum.
-    // Therefore, the payload itself has 1224 - 7 = 1217 bytes of space.
-    const MAX_SIGN_REQ_DATA_SIZE = 1152;
-    if (req.payload.length > MAX_SIGN_REQ_DATA_SIZE)
+
+    if (req.payload.length > fwConstants.reqMaxDataSz)
       return cb('Transaction is too large');
 
     // Build the payload
-    const payload = Buffer.alloc(2 + MAX_SIGN_REQ_DATA_SIZE);
+    const payload = Buffer.alloc(2 + fwConstants.reqMaxDataSz);
     let off = 0;
     // Copy request schema (e.g. ETH or BTC transfer)
     payload.writeUInt16BE(req.schema, off); off += 2;
@@ -483,7 +487,11 @@ class Client {
     let off = 0;
     const pairingStatus = res.readUInt8(off); off++;
     // If we are already paired, we get the next ephemeral key
-    const pub = res.slice(off, res.length).toString('hex');
+    const pub = res.slice(off, off + 65).toString('hex'); off += 65;
+    // Grab the firmware version (will be 0-length for older fw versions)
+    // It is of format |fix|minor|major|reserved|
+    this.fwVersion = res.slice(off);
+    // Set the public key
     this.ephemeralPub = getP256KeyPairFromPub(pub);
     // return the state of our pairing
     return (pairingStatus === messageConstants.PAIRED);

--- a/src/constants.js
+++ b/src/constants.js
@@ -116,8 +116,6 @@ const ethMsgProtocol = {
     SIGN_PERSONAL: 0,
 }
 
-const ETH_DATA_MAX_SIZE = 1024; // Maximum number of bytes that can go in the data field
-const ETH_MSG_MAX_SIZE = 1024; // Maximum number of bytes that can be used in a message signing request
 const REQUEST_TYPE_BYTE = 0x02; // For all HSM-bound requests
 const VERSION_BYTE = 1;
 const HARDENED_OFFSET = 0x80000000; // Hardened offset
@@ -179,7 +177,25 @@ const ETH_ABI_LATTICE_FW_TYPE_MAP = {
     'string': 50,
 };
 
+function getFwVersionConst(v) {
+    const c = {
+        reqMaxDataSz: 1152,
+    };
+    if (v.length === 0 || (v[1] < 10 && v[2] === 0)) {
+        c.ethMaxDataSz = c.reqMaxDataSz - 128;
+        c.ethMaxMsgSz = c.ethMaxDataSz;
+        c.ethMaxGasPrice = 500000000000; // 500 gwei
+    } else if (v[1] >= 10 && v[2] >= 0) {
+        c.reqMaxDataSz = 1678;
+        c.ethMaxDataSz = c.reqMaxDataSz - 128;
+        c.ethMaxMsgSz = c.ethMaxDataSz;
+        c.ethMaxGasPrice = 1000000000000; // 1000 gwei
+    }
+    return c;
+}
+
 module.exports = {
+    getFwVersionConst,
     ADDR_STR_LEN,
     AES_IV,
     BASE_URL,
@@ -193,8 +209,6 @@ module.exports = {
     responseCodes,
     responseMsgs,
     signingSchema,
-    ETH_DATA_MAX_SIZE,
-    ETH_MSG_MAX_SIZE,
     REQUEST_TYPE_BYTE,
     VERSION_BYTE,
     HARDENED_OFFSET,

--- a/test/testAbi.js
+++ b/test/testAbi.js
@@ -213,7 +213,8 @@ function createDef() {
   def.sig = ethAbi.methodID(def.name, def._typeNames).toString('hex');
   const data = helpers.ensureHexBuffer(buildEthData(def));
   // Make sure the transaction will fit in the firmware buffer size
-  if (data.length > constants.ETH_DATA_MAX_SIZE)
+  const fwConstants = constants.getFwVersionConst(client.fwVersion)
+  if (data.length > fwConstants.ethMaxDataSz)
     return createDef();
   
   return def;

--- a/test/testAbi.js
+++ b/test/testAbi.js
@@ -533,8 +533,6 @@ describe('Test ABI Markdown', () => {
   })
 
   it.each(indices, 'Test ABI markdown of payload #%s', ['i'], async (n, next) => {
-    if (n.i < 7)
-      return setTimeout(() => {next()}, 1000);
     const def = abiDefs[n.i];
     req.data.data = buildEthData(def)
     try {

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -143,9 +143,10 @@ describe('Connect and Pair', () => {
 
   it('Should sign Ethereum transactions', async () => {
     // Constants from firmware
-    const GAS_PRICE_MAX = 100000000000;
+    const fwConstants = constants.getFwVersionConst(client.fwVersion)
+    const GAS_PRICE_MAX = fwConstants.ethMaxGasPrice;
     const GAS_LIMIT_MIN = 22000;
-    const GAS_LIMIT_MAX = 10000000;
+    const GAS_LIMIT_MAX = 12500000;
     
     const txData = {
       nonce: 0,
@@ -172,6 +173,11 @@ describe('Connect and Pair', () => {
     tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
     req.data.chainId = 'rinkeby';
+
+    req.data.data = client.crypto.randomBytes(fwConstants.ethMaxDataSz).toString('hex');
+    tx = await(helpers.sign(client, req));
+    expect(tx.tx).to.not.equal(null);
+    req.data.data = null;
 
     // Invalid chainId
     req.data.chainId = 'notachain';
@@ -248,7 +254,7 @@ describe('Connect and Pair', () => {
     req.data.value = 0.3 * 10 ** 18;
     
     // Data too large
-    req.data.data = client.crypto.randomBytes(constants.ETH_DATA_MAX_SIZE + 1).toString('hex');
+    req.data.data = client.crypto.randomBytes(fwConstants.ethMaxDataSz + 1).toString('hex');
     try {
       tx = await(helpers.sign(client, req));
       expect(tx.tx).to.equal(null);


### PR DESCRIPTION
This PR adds a backward-and-forward compatibility mechanism to check the firmware version returned by `connect`.

* Lattice firmware `<=0.9.8`: Does not return a firmware version.
* Lattice firmware `>=0.10.0`: Returns a firmware version.

We use the firmware version to determine certain constants, mainly related to sizes of messages. The first instance is included in this PR, which is the ETH max data size, which moves from `1024 bytes` to `1550 bytes` in `v0.10.0`.