### PR TITLE
Adds ability to skip the cache and request any address

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ client.addresses(req, (err, res) => {
 |:-----------|:----------|:-----------------|:----------------|:----------------------|
 | `startPath` | Array    | none             | n/a             | First address path in BIP44 tree to return. You must provide 5 indices to form the path. |
 | `n`        | number    | 1                | n/a             | Number of subsequent addresses after `start` to derive. These will increment over the final index in the path |
+| `skipCache` | bool     | false            | n/a             | If set to true, skip the restriction that only cached addresses may be requested. This allows the user to request any address for a supported currency (BTC and ETH) |
 
 **Response:**
 
@@ -131,9 +132,12 @@ res = [
 ]
 ```
 
-## Restrictions on Lattice addresses
+## The Address Cache
 
-Although the request is generalized, the Lattice will only serve certain addresses. The following are restrictions for the existing version of Lattice firmware:
+If `skipCache=false`, the requester may only fetch addresses that have been saved to the Lattice's cache. This is used mainly for BTC to keep track
+of which addresses have been generated in an effort to sync an HD wallet. **Since the gap limit of ETH is 0, caching isn't relevant for it, so you should generally use `skipCache=true` when requesting ETH addresses.**
+
+The following restrictions apply when using `skipCache=false`:
 
 * `ETH`: The Lattice only returns the 0-th index address (`m/44'/60'/0'/0/0`) of the current wallet (either on-board Lattice or external SafeCard). This means `n` must be equal to `1` and the only acceptable path is that of the 0-th index address.
 * `BTC`: Currently we only support `p2sh-p2wpkh` BTC addresses which use [BIP49](https://en.bitcoin.it/wiki/BIP_0049): `m/49'/0'/0'/0/x`. If testnet is enabled (`testnet3`), we also allow `m/49'/1'/0'/0/x`. Here, `x` may be any address that has been "cached" by the Lattice. We cache addresses relative to the requested address based on the [gap limit](https://blog.blockonomics.co/bitcoin-what-is-this-gap-limit-4f098e52d7e1?gi=616654046ec4). For the regular wallet, the gap limit is 20. In addition to these addresses, the user may request change addresses (`m/49'/0'/0/1/x` and `m/49'/1'/0'/1/x`). The gap limit for change addresses is 1. Because the Lattice itself is stateless, it creates new addresses whenever previous addresses are requested. For example, if regular addresses 0-19 have been cached (i.e. on an initial cache) and the user requests addresses 9-19, the wallet would then cache 20-29 and the user could then request any of those addresses (which would, in turn, lead to more becoming available). The same logic applies for change addresses, but only the subsequent one would get cached. Note that if you request addresses outside of the gap limit, you will get an error and no new addresses will be cached.

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,11 @@
         "wif": "^2.0.1"
       }
     },
+    "bitwise": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bitwise/-/bitwise-2.0.4.tgz",
+      "integrity": "sha512-ZOByl1Sc8SH2/owfRfR1apaC1ELNqHqAAtfqs1Ixqk/9Bod6VxWz10MiMYXkNiL95RdFAqOGQxm1TCGPf1iFyw=="
+    },
     "blakejs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "aes-js": "^3.1.1",
     "bignumber.js": "^9.0.1",
+    "bitwise": "^2.0.4",
     "bs58": "^4.0.1",
     "bs58check": "^2.1.2",
     "buffer": "^5.6.0",

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -89,8 +89,30 @@ describe('Connect and Pair', () => {
       expect(addrs.length).to.equal(1);
       expect(addrs[0][0]).to.be.oneOf(['n', 'm', '2']);
       addrData.startPath[1] = helpers.BTC_COIN;
+
+      // Keys outside the cache with skipCache = true
+      addrData.startPath[4] = 1000000;
+      addrData.n = 3;
+      addrData.skipCache = true;
+      console.log('requesting', addrData)
+      addrs = await helpers.getAddresses(client, addrData, 2000);
+      console.log('addrs?', addrs)
+      expect(addrs.length).to.equal(addrData.n);
       
       // --- EXPECTED FAILURES ---
+      // Keys outside the cache with skipCache = false
+      addrData.startPath[4] = 1000000;
+      addrData.n = 3;
+      addrData.skipCache = false;
+      try {
+        addrs = await helpers.getAddresses(client, addrData, 2000);
+        expect(addrs).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      addrData.startPath[4] = 0;
+      addrData.n = 1;
+
       // Unsupported purpose (m/<purpose>/)
       addrData.startPath[0] = 0; // Purpose 0 -- undefined
       try {

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -94,9 +94,7 @@ describe('Connect and Pair', () => {
       addrData.startPath[4] = 1000000;
       addrData.n = 3;
       addrData.skipCache = true;
-      console.log('requesting', addrData)
       addrs = await helpers.getAddresses(client, addrData, 2000);
-      console.log('addrs?', addrs)
       expect(addrs.length).to.equal(addrData.n);
       
       // --- EXPECTED FAILURES ---

--- a/test/testWalletJobs.js
+++ b/test/testWalletJobs.js
@@ -492,6 +492,32 @@ describe('Wallet sync tests (starting with newly synced wallet)', () => {
     helpers.validateBTCAddresses(res, jobData, activeWalletSeed); 
   })
 
+  it('Should fetch BTC addresses outside the cache with the proper flag set', async () => {
+    const req = { 
+      currency: 'BTC', 
+      startPath: [helpers.BTC_PURPOSE_P2SH_P2WPKH, helpers.BTC_COIN, 123, 87290, 28802208], 
+      n: 3,
+      skipCache: true,
+    }
+    const addrs = await helpers.getAddresses(client, req, 2000);
+    const resp = {
+      count: addrs.length,
+      addresses: addrs,
+    }
+    const jobData = {
+      parent: {
+        pathDepth: 4,
+        purpose: req.startPath[0],
+        coin: req.startPath[1],
+        account: req.startPath[2],
+        change: req.startPath[3],
+      },
+      count: req.n,
+      first: req.startPath[4],
+    }
+    helpers.validateBTCAddresses(resp, jobData, Buffer.allocUnsafe(32));
+  })
+
   it('Should wait while the wallet syncs new addresses (BTC->39)', (done) => {
     waitForSync(20, done);
   })


### PR DESCRIPTION
We were previously blocking `getAddress` requests if the requested address(es) were outside of the existing address cache. For Ethereum this was especially cumbersome since its gap limit is 0 so we never cache more than one address on-device.

This PR corresponds to a firmware change that allows the user to set a bitwise flag indicating the device should skip the cache-only requirement and simply fetch the addresses from the onboard wallet (either Lattice or SafeCard -- whichever is active).

The maximum allowed addresses per request is still 10, which fits in a 4-bit nibble.