### PR TITLE
Bumps version to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1792,16 +1792,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",


### PR DESCRIPTION
**Changelog**:

* #115: Support for loading smart contract ABI functions into the Lattice. When a user creates a transaction request against a known ABI function (identified by the 4-byte prefix and canonical function signature), the transaction will be "marked down" in such a way that shows the user the human readable parameter names and corresponding request values.
* #116: Permissions v0. Adds an exported function allowing a paired requester to create a "permission", where each permission sets a spending limit in the given currency, which resets after each specified interval. For example, a requester could create a permission allowing them to autosign ETH transfers of up to 1 ETH per 24 hour period. Note that only ETH and BTC transfers are allowable permissions at the moment, but more complex functionality and rule setting could be added later.
* #117: Adds mechanism to determine various firmware constants based on the returned firmware version. This will be necessary for backwards compatibility in future versions.
* #118: Adds `skipCache` param to `getAddresses` that allows the user to request an address at any index (note that this is only allowed for supported currencies).
* #120: Sets `skipCache=true` by default, allowing a requester to request *any* ETH/BTC address by default, i.e. unrestricted by the device's cache state.