### PR TITLE
Changes default `skipCache` value to true

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ client.addresses(req, (err, res) => {
 |:-----------|:----------|:-----------------|:----------------|:----------------------|
 | `startPath` | Array    | none             | n/a             | First address path in BIP44 tree to return. You must provide 5 indices to form the path. |
 | `n`        | number    | 1                | n/a             | Number of subsequent addresses after `start` to derive. These will increment over the final index in the path |
-| `skipCache` | bool     | false            | n/a             | If set to true, skip the restriction that only cached addresses may be requested. This allows the user to request any address for a supported currency (BTC and ETH) |
+| `skipCache` | bool     | true            | n/a             | If set to true, skip the restriction that only cached addresses may be requested. This allows the user to request any address for a supported currency (BTC and ETH) |
 
 **Response:**
 

--- a/src/client.js
+++ b/src/client.js
@@ -156,7 +156,7 @@ class Client {
   getAddresses(opts, cb) {
     const SKIP_CACHE_FLAG = 1;
     const MAX_ADDR = 10;
-    const { startPath, n, skipCache=false } = opts;
+    const { startPath, n, skipCache=true } = opts;
     if (startPath === undefined || n === undefined || startPath.length !== 5) {
       return cb('Please provide `startPath` and `n` options');
     } else if (n > MAX_ADDR) {

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -63,7 +63,8 @@ describe('Connect and Pair', () => {
       const addrData = { 
         currency: 'BTC', 
         startPath: [helpers.BTC_PURPOSE_P2SH_P2WPKH, helpers.BTC_COIN, HARDENED_OFFSET, 0, 0], 
-        n: 5
+        n: 5,
+        skipCache: false,
       }
       // Bitcoin addresses
       // NOTE: The format of address will be based on the user's Lattice settings


### PR DESCRIPTION
Most applications will not be utilizing the cache. Really the only
place that needs to is the web wallet for BTC addresses. Most users of
this SDK will be external Ethereum apps, which do not need to worry
about caching of addresses.