### PR TITLE
Blocks bitwise flags in getAddresses for old Lattice fw

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ client.addresses(req, (err, res) => {
 |:-----------|:----------|:-----------------|:----------------|:----------------------|
 | `startPath` | Array    | none             | n/a             | First address path in BIP44 tree to return. You must provide 5 indices to form the path. |
 | `n`        | number    | 1                | n/a             | Number of subsequent addresses after `start` to derive. These will increment over the final index in the path |
-| `skipCache` | bool     | true            | n/a             | If set to true, skip the restriction that only cached addresses may be requested. This allows the user to request any address for a supported currency (BTC and ETH) |
+| `skipCache` | bool     | true            | n/a             | If set to true, skip the restriction that only cached addresses may be requested. This allows the user to request any address for a supported currency (BTC and ETH). Ignored for Lattice firmware versions <0.10.0 |
 
 **Response:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/client.js
+++ b/src/client.js
@@ -178,9 +178,15 @@ class Client {
     // Specify the number of subsequent addresses to request.
     // We also allow the user to skip the cache and request any address related to the asset
     // in the wallet.
-    const flag = skipCache === true ? bitwise.nibble.read(SKIP_CACHE_FLAG) : bitwise.nibble.read(0);
-    const count = bitwise.nibble.read(n);
-    const val = bitwise.byte.write(flag.concat(count));
+    let val;
+    const fwConstants = getFwVersionConst(this.fwVersion);
+    if (true === fwConstants.addrFlagsAllowed) {
+      const flag = skipCache === true ? bitwise.nibble.read(SKIP_CACHE_FLAG) : bitwise.nibble.read(0);
+      const count = bitwise.nibble.read(n);
+      val = bitwise.byte.write(flag.concat(count));
+    } else {
+      val = n;
+    }
     payload.writeUInt8(val, off); off++;
     const param = this._buildEncRequest(encReqCodes.GET_ADDRESSES, payload);
     return this._request(param, (err, res) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -185,11 +185,13 @@ function getFwVersionConst(v) {
         c.ethMaxDataSz = c.reqMaxDataSz - 128;
         c.ethMaxMsgSz = c.ethMaxDataSz;
         c.ethMaxGasPrice = 500000000000; // 500 gwei
+        c.addrFlagsAllowed = false;
     } else if (v[1] >= 10 && v[2] >= 0) {
         c.reqMaxDataSz = 1678;
         c.ethMaxDataSz = c.reqMaxDataSz - 128;
         c.ethMaxMsgSz = c.ethMaxDataSz;
         c.ethMaxGasPrice = 1000000000000; // 1000 gwei
+        c.addrFlagsAllowed = true;
     }
     return c;
 }


### PR DESCRIPTION
This feature is not backwards compatible, so we need to block its
usage for older Lattice versions