### PR TITLE
Skip ABI parsing error option + new ABI test

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -783,10 +783,10 @@ class Client {
   }
 
   // TODO: Find a better way to export this.
-  parseAbi(source, data) {
+  parseAbi(source, data, skipErrors=false) {
     switch (source) {
       case 'etherscan':
-        return abiParsers[source](data);
+        return abiParsers[source](data, skipErrors);
       default:
         return { err: `No ${source} parser available.` };
 

--- a/src/ethereumAbi.js
+++ b/src/ethereumAbi.js
@@ -87,17 +87,24 @@ exports.getFuncSig = function(f) {
 //--------------------------------------
 // PARSERS
 //--------------------------------------
-function parseEtherscanAbiDefs(_defs) { // `_defs` are `result` of the parsed response
+function parseEtherscanAbiDefs(_defs, skipErrors=false) { // `_defs` are `result` of the parsed response
   const defs = [];
   _defs.forEach((d) => {
     if (d.name && d.inputs && d.type === 'function' && d.stateMutability !== 'view' && d.constant !== true) {
-      const sig = exports.getFuncSig(d);
-      const params = parseEtherscanAbiInputs(d.inputs);
-      defs.push({
-        name: d.name,
-        sig,
-        params,
-      })
+      try {
+        const sig = exports.getFuncSig(d);
+        const params = parseEtherscanAbiInputs(d.inputs);
+        defs.push({
+          name: d.name,
+          sig,
+          params,
+        })
+      } catch (err) {
+        if (skipErrors === true)
+          console.error('Failed to load def:', d.name, err.toString())
+        else
+          throw new Error(err)
+      }
     }
   })
   return defs;

--- a/test/testAbi.js
+++ b/test/testAbi.js
@@ -545,6 +545,20 @@ describe('Preloaded ABI definitions', () => {
       expect(err).to.equal(null);
     }
   })
+
+  it('Should test Uniswap swapExactEthForTokens', async () => {
+    // From this transaction:
+    // https://etherscan.io/tx/0xe777b55a2a156e37039676fe77b13c4f9e4fac1b859ca2cc610bec52a7bb3d5a
+    const data = '0x7ff36ab500000000000000000000000000000000000000000000000e77e14404341f35220000000000000000000000000000000000000000000000000000000000000080000000000000000000000000cba92e14525ba7e38627a06665213996462ec23200000000000000000000000000000000000000000000000000000000603e96510000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000b4d930279552397bba2ee473229f89ec245bc365'
+    req.data.data = helpers.ensureHexBuffer(data);
+    try {
+      const sigResp = await helpers.sign(client, req);
+      expect(sigResp.tx).to.not.equal(null);
+      expect(sigResp.txHash).to.not.equal(null);
+    } catch (err) {
+      expect(err).to.equal(null)
+    }
+  })
 })
 
 describe('Add ABI definitions', () => {


### PR DESCRIPTION
Adds option to skip errors when parsing ABI defs and adds one more ABI def test for new pre-loaded def.