### PR TITLE
Signtx v2

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -217,7 +217,6 @@ class Client {
     // the 2-byte schemaId since it is not returned from our resolver.
     // Note that different firmware versions may have different data sizes.
     const fwConstants = getFwVersionConst(this.fwVersion);
-
     // Build the signing request payload to send to the device. If we catch
     // bad params, return an error instead
     // data.ethMaxDataSz = fwConstants.ethMaxDataSz;
@@ -242,7 +241,7 @@ class Client {
     const payload = Buffer.alloc(2 + fwConstants.reqMaxDataSz);
     let off = 0;
     // Whether there will be follow up requests
-    const hasExtraPayloads = Number(req.extraDataPayloads.length > 0);
+    const hasExtraPayloads = req.extraPayloads && Number(req.extraDataPayloads.length > 0);
     payload.writeUInt8(hasExtraPayloads, off); off += 1;  
     // Copy request schema (e.g. ETH or BTC transfer)
     payload.writeUInt8(schema, off); off += 1;

--- a/src/client.js
+++ b/src/client.js
@@ -241,7 +241,7 @@ class Client {
     const payload = Buffer.alloc(2 + fwConstants.reqMaxDataSz);
     let off = 0;
     // Whether there will be follow up requests
-    const hasExtraPayloads = req.extraPayloads && Number(req.extraDataPayloads.length > 0);
+    const hasExtraPayloads = req.extraDataPayloads && Number(req.extraDataPayloads.length > 0);
     payload.writeUInt8(hasExtraPayloads, off); off += 1;  
     // Copy request schema (e.g. ETH or BTC transfer)
     payload.writeUInt8(schema, off); off += 1;

--- a/src/client.js
+++ b/src/client.js
@@ -219,8 +219,6 @@ class Client {
     const fwConstants = getFwVersionConst(this.fwVersion);
     // Build the signing request payload to send to the device. If we catch
     // bad params, return an error instead
-    // data.ethMaxDataSz = fwConstants.ethMaxDataSz;
-    // data.ethMaxMsgSz = fwConstants.ethMaxMsgSz;
     data = { fwConstants, ...data};
     let req, reqPayload;
     let schema;

--- a/src/constants.js
+++ b/src/constants.js
@@ -201,7 +201,8 @@ const ETH_ABI_LATTICE_FW_TYPE_MAP = {
 function getFwVersionConst(v) {
     const c = {
         reqMaxDataSz: 1152,
-        extraDataAllowed: false,
+        extraDataFrameSz: 0,
+        extraDataMaxFrames: 0,
     };
     function gte(v, exp) {
         return v[0] >= exp[0] || v[1] >= exp[1] || v[2] >= exp[2];
@@ -223,7 +224,6 @@ function getFwVersionConst(v) {
         c.addrFlagsAllowed = true;
         c.extraDataFrameSz = 100; // 1500 bytes per frame of extraData allowed
         c.extraDataMaxFrames = 1;  // 1 frame of extraData allowed
-        c.extraDataAllowed = true;        
     } else {
         // >=0.10.0
         c.reqMaxDataSz = 1678;

--- a/src/constants.js
+++ b/src/constants.js
@@ -200,13 +200,31 @@ const ETH_ABI_LATTICE_FW_TYPE_MAP = {
 function getFwVersionConst(v) {
     const c = {
         reqMaxDataSz: 1152,
+        extraDataAllowed: false,
     };
-    if (v.length === 0 || (v[1] < 10 && v[2] === 0)) {
+    function gte(v, exp) {
+        return v[0] >= exp[0] || v[1] >= exp[1] || v[2] >= exp[2];
+    }
+    if (v.length === 0 || !gte(v, [0, 10, 0])) {
+        // Legacy versions (<0.10.0)
         c.ethMaxDataSz = c.reqMaxDataSz - 128;
         c.ethMaxMsgSz = c.ethMaxDataSz;
         c.ethMaxGasPrice = 500000000000; // 500 gwei
         c.addrFlagsAllowed = false;
-    } else if (v[1] >= 10 && v[2] >= 0) {
+        return c;
+    } 
+    if (gte(v, [0, 10, 4])) {
+        // >=0.10.3
+        c.reqMaxDataSz = 1678;
+        c.ethMaxDataSz = c.reqMaxDataSz - 128;
+        c.ethMaxMsgSz = c.ethMaxDataSz;
+        c.ethMaxGasPrice = 20000000000000; // 20000 gwei
+        c.addrFlagsAllowed = true;
+        c.extraDataFrameSz = 1500; // 1500 bytes per frame of extraData allowed
+        c.extraDataMaxFrames = 1;  // 1 frame of extraData allowed
+        c.extraDataAllowed = true;        
+    } else {
+        // >=0.10.0
         c.reqMaxDataSz = 1678;
         c.ethMaxDataSz = c.reqMaxDataSz - 128;
         c.ethMaxMsgSz = c.ethMaxDataSz;

--- a/src/constants.js
+++ b/src/constants.js
@@ -222,7 +222,7 @@ function getFwVersionConst(v) {
         c.ethMaxMsgSz = c.ethMaxDataSz;
         c.ethMaxGasPrice = 20000000000000; // 20000 gwei
         c.addrFlagsAllowed = true;
-        c.extraDataFrameSz = 100; // 1500 bytes per frame of extraData allowed
+        c.extraDataFrameSz = 1500; // 1500 bytes per frame of extraData allowed
         c.extraDataMaxFrames = 1;  // 1 frame of extraData allowed
     } else {
         // >=0.10.0

--- a/src/constants.js
+++ b/src/constants.js
@@ -110,6 +110,7 @@ const signingSchema = {
     ETH_TRANSFER: 1,
     ERC20_TRANSFER: 2,
     ETH_MSG: 3,
+    EXTRA_DATA: 4,
 }
 
 const ethMsgProtocol = {
@@ -220,7 +221,7 @@ function getFwVersionConst(v) {
         c.ethMaxMsgSz = c.ethMaxDataSz;
         c.ethMaxGasPrice = 20000000000000; // 20000 gwei
         c.addrFlagsAllowed = true;
-        c.extraDataFrameSz = 1500; // 1500 bytes per frame of extraData allowed
+        c.extraDataFrameSz = 100; // 1500 bytes per frame of extraData allowed
         c.extraDataMaxFrames = 1;  // 1 frame of extraData allowed
         c.extraDataAllowed = true;        
     } else {

--- a/src/constants.js
+++ b/src/constants.js
@@ -205,7 +205,11 @@ function getFwVersionConst(v) {
         extraDataMaxFrames: 0,
     };
     function gte(v, exp) {
-        return v[0] >= exp[0] || v[1] >= exp[1] || v[2] >= exp[2];
+        // Note that `v` fields come in as [fix|minor|major]
+        return  (v[2] > exp[0]) || 
+                (v[2] === exp[0] && v[1] > exp[1]) || 
+                (v[2] === exp[0] && v[1] === exp[1] && v[0] > exp[2]) ||
+                (v[2] === exp[0] && v[1] === exp[1] && v[0] === exp[2]);
     }
     if (v.length === 0 || !gte(v, [0, 10, 0])) {
         // Legacy versions (<0.10.0)

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -17,7 +17,7 @@ exports.buildEthereumMsgRequest = function(input) {
     msg: null, // Save the buffered message for later
   }
   const { ethMaxMsgSz, extraDataFrameSz, extraDataMaxFrames } = input.fwConstants;
-  const MAX_BASE_MSG_SZ = ethMaxMsgSz; // TODO: Incorporate expanded sizes for ETH_MSG
+  const MAX_BASE_MSG_SZ = ethMaxMsgSz;
   const EXTRA_DATA_ALLOWED = extraDataFrameSz > 0 && extraDataMaxFrames > 0;
   if (input.protocol === 'signPersonal') {
     const L = ((input.signerPath.length + 1) * 4) + MAX_BASE_MSG_SZ + 4;

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -194,10 +194,9 @@ exports.buildEthereumTxRequest = function(data) {
       if (extraDataAllowed) {
         const frames = splitFrames(dataBytes.slice(dataSliceSz), extraDataFrameSz);
         frames.forEach((frame) => {
-          const tmpPayload = Buffer.alloc(4 + extraDataFrameSz);
-          tmpPayload.writeUInt32LE(frame.length);
-          frame.copy(tmpPayload, 4);
-          extraDataPayloads.push(tmpPayload);
+          const szLE = Buffer.alloc(4);
+          szLE.writeUInt32LE(frame.length);
+          extraDataPayloads.push(Buffer.concat([szLE, frame]));
         })
       }
     }

--- a/test/testAbi.js
+++ b/test/testAbi.js
@@ -239,7 +239,8 @@ function createDef() {
   const data = helpers.ensureHexBuffer(buildEthData(def));
   // Make sure the transaction will fit in the firmware buffer size
   const fwConstants = constants.getFwVersionConst(client.fwVersion)
-  if (data.length > fwConstants.ethMaxDataSz)
+  const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
+  if (data.length > maxDataSz)
     return createDef();
   return def;
 }
@@ -304,9 +305,10 @@ function createTupleDef() {
   def._typeNames = getTypeNames(def.params.slice(0, def.params.length - numTupleParams));
   // Make sure the transaction will fit in the firmware buffer size
   const fwConstants = constants.getFwVersionConst(client.fwVersion)
+  const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
   def.sig = buildFuncSelector(def);
   const data = helpers.ensureHexBuffer(buildEthData(def));
-  if (data.length > fwConstants.ethMaxDataSz)
+  if (data.length > maxDataSz)
     return createTupleDef();
   return def;
 }

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -56,7 +56,7 @@ describe('Connect and Pair', () => {
       expect(client.hasActiveWallet()).to.equal(true);
     }
   });
-/*
+
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);
     if (caughtErr === false) {
@@ -141,7 +141,7 @@ describe('Connect and Pair', () => {
       }
     }
   });
-*/
+
   it('Should sign Ethereum transactions', async () => {
     // Constants from firmware
     const fwConstants = constants.getFwVersionConst(client.fwVersion)
@@ -168,8 +168,8 @@ describe('Connect and Pair', () => {
     // Sign a tx that does not use EIP155 (no EIP155 on rinkeby for some reason)
     let tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
+
     // Sign a tx with EIP155
-    /*
     req.data.chainId = 'mainnet';
     tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
@@ -179,17 +179,7 @@ describe('Connect and Pair', () => {
     tx = await(helpers.sign(client, req));
     expect(tx.tx).to.not.equal(null);
     req.data.data = null;
-*/
-    // Max data
-    const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
-    console.log('fwConstants', fwConstants)
-    console.log('maxDataSz', maxDataSz)
-    const tmpSz = fwConstants.ethMaxDataSz+20 //  +10 works but +20 doesn't for some reason! FIND OUT WHY
-    req.data.data = client.crypto.randomBytes(tmpSz).toString('hex');
-    tx = await(helpers.sign(client, req));
-    expect(tx.tx).to.not.equal(null);
-    req.data.data = null;
-/*
+
     // Invalid chainId
     req.data.chainId = 'notachain';
     try {
@@ -240,7 +230,7 @@ describe('Connect and Pair', () => {
       expect(err).to.not.equal(null);
     }
     // Reset to valid param
-    req.data.gasLimit = 1200000000;
+    req.data.gasPrice = 1200000000;
 
     // `to` wrong size
     req.data.to = '0xe242e54155b1abc71fc118065270cecaaf8b77'
@@ -263,8 +253,12 @@ describe('Connect and Pair', () => {
     }
     // Reset to valid param
     req.data.value = 0.3 * 10 ** 18;
-    
-    // Data too large
+
+    // Test data range
+    const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
+    req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
+    tx = await(helpers.sign(client, req));
+    expect(tx.tx).to.not.equal(null);
     req.data.data = client.crypto.randomBytes(maxDataSz+1).toString('hex');
     try {
       tx = await(helpers.sign(client, req));
@@ -272,9 +266,14 @@ describe('Connect and Pair', () => {
     } catch (err) {
       expect(err).to.not.equal(null);
     }
-*/
+    req.data.data = client.crypto.randomBytes(fwConstants.ethMaxDataSz).toString('hex');
+    tx = await(helpers.sign(client, req));
+    expect(tx.tx).to.not.equal(null);
+    req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
+    tx = await(helpers.sign(client, req));
+    expect(tx.tx).to.not.equal(null);
   });
-/*
+
   it('Should sign legacy Bitcoin inputs', async () => {  
     const txData = {
       prevOuts: [
@@ -403,5 +402,5 @@ describe('Connect and Pair', () => {
     expect(signResp.tx).to.not.equal(null);
 
   })
-*/
+
 });

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -165,11 +165,11 @@ describe('Connect and Pair', () => {
         chainId: 'rinkeby', // Can also be an integer
       }
     }
-
     // Sign a tx that does not use EIP155 (no EIP155 on rinkeby for some reason)
     let tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
     // Sign a tx with EIP155
+    /*
     req.data.chainId = 'mainnet';
     tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
@@ -179,7 +179,17 @@ describe('Connect and Pair', () => {
     tx = await(helpers.sign(client, req));
     expect(tx.tx).to.not.equal(null);
     req.data.data = null;
-
+*/
+    // Max data
+    const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
+    console.log('fwConstants', fwConstants)
+    console.log('maxDataSz', maxDataSz)
+    const tmpSz = fwConstants.ethMaxDataSz+20 //  +10 works but +20 doesn't for some reason! FIND OUT WHY
+    req.data.data = client.crypto.randomBytes(tmpSz).toString('hex');
+    tx = await(helpers.sign(client, req));
+    expect(tx.tx).to.not.equal(null);
+    req.data.data = null;
+/*
     // Invalid chainId
     req.data.chainId = 'notachain';
     try {
@@ -255,14 +265,14 @@ describe('Connect and Pair', () => {
     req.data.value = 0.3 * 10 ** 18;
     
     // Data too large
-    req.data.data = client.crypto.randomBytes(fwConstants.ethMaxDataSz + 1).toString('hex');
+    req.data.data = client.crypto.randomBytes(maxDataSz+1).toString('hex');
     try {
       tx = await(helpers.sign(client, req));
       expect(tx.tx).to.equal(null);
     } catch (err) {
       expect(err).to.not.equal(null);
     }
-
+*/
   });
 /*
   it('Should sign legacy Bitcoin inputs', async () => {  

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -56,7 +56,7 @@ describe('Connect and Pair', () => {
       expect(client.hasActiveWallet()).to.equal(true);
     }
   });
-
+/*
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);
     if (caughtErr === false) {
@@ -141,7 +141,7 @@ describe('Connect and Pair', () => {
       }
     }
   });
-
+*/
   it('Should sign Ethereum transactions', async () => {
     // Constants from firmware
     const fwConstants = constants.getFwVersionConst(client.fwVersion)
@@ -264,7 +264,7 @@ describe('Connect and Pair', () => {
     }
 
   });
-
+/*
   it('Should sign legacy Bitcoin inputs', async () => {  
     const txData = {
       prevOuts: [
@@ -393,4 +393,5 @@ describe('Connect and Pair', () => {
     expect(signResp.tx).to.not.equal(null);
 
   })
+*/
 });

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -460,17 +460,6 @@ describe('Test ETH personalSign', function() {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');
   })
 
-  it.each(randomTxDataLabels, 'Msg: sign_personal #%s', ['label'], async function(n, next) {
-    const protocol = 'signPersonal';
-    const payload = buildRandomMsg(protocol);
-    try {
-      await testMsg(buildMsgReq(payload, protocol))
-      setTimeout(() => { next() }, 2500);
-    } catch (err) {
-      setTimeout(() => { next(err) }, 2500);
-    }
-  })
-
   it('Should throw error when message contains non-ASCII characters', async () => {
     const protocol = 'signPersonal';
     const msg = '⚠️';
@@ -482,12 +471,24 @@ describe('Test ETH personalSign', function() {
   it('Msg: sign_personal boundary conditions', async () => {
     const protocol = 'signPersonal';
     const fwConstants = constants.getFwVersionConst(client.fwVersion);
-    const maxSz = fwConstants.ethMaxDataSz;
-    const maxValid = `0x${crypto.randomBytes(maxSz).toString('hex')}`;
-    const minInvalid = `0x${crypto.randomBytes(maxSz + 1).toString('hex')}`;
+    const maxMsgSz = fwConstants.ethMaxMsgSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
+    const maxValid = `0x${crypto.randomBytes(maxMsgSz).toString('hex')}`;
+    const minInvalid = `0x${crypto.randomBytes(maxMsgSz + 1).toString('hex')}`;
     const zeroInvalid = '0x';
     await testMsg(buildMsgReq(maxValid, protocol), true);
     await testMsg(buildMsgReq(minInvalid, protocol), false);
     await testMsg(buildMsgReq(zeroInvalid, protocol), false);
   })
+
+  it.each(randomTxDataLabels, 'Msg: sign_personal #%s', ['label'], async function(n, next) {
+    const protocol = 'signPersonal';
+    const payload = buildRandomMsg(protocol);
+    try {
+      await testMsg(buildMsgReq(payload, protocol))
+      setTimeout(() => { next() }, 2500);
+    } catch (err) {
+      setTimeout(() => { next(err) }, 2500);
+    }
+  })
+
 })

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -22,6 +22,8 @@ const EthTx = require('ethereumjs-tx').Transaction;
 const constants = require('./../src/constants')
 const expect = require('chai').expect;
 const helpers = require('./testUtil/helpers');
+const seedrandom = require('seedrandom');
+const prng = new seedrandom(process.env.SEED || 'myrandomseed');
 const HARDENED_OFFSET = constants.HARDENED_OFFSET;
 let client = null;
 let numRandom = 20; // Number of random tests to conduct
@@ -41,21 +43,46 @@ const defaultTxData = {
   data: null
 };
 
+function randInt(n) {
+  return Math.floor(n * prng.quick());
+}
+
 function buildIterLabels() {
   for (let i = 0; i < numRandom; i++)
     randomTxDataLabels.push({ label: `${i+1}/${numRandom}`, number: i })
 }
 
-function buildRandomTxData() {
-  // Constants from firmware
+// Test boundaries for chainId sizes. We allow chainIds up to MAX_UINT64, but
+// the mechanism to test is different for chainIds >254.
+// NOTE: All unknown chainIds lead to using EIP155 (which includes all of these)
+function getChainId(pow, add) {
+  return `0x${new BN(2).pow(pow).plus(add).toString(16)}`
+}
+
+function getFakeChain() {
+  return {
+    'name': 'myFakeChain',
+    'chainId': 0,
+    'networkId': 0,
+    'genesis': {},
+    'hardforks': [],
+    'bootstrapNodes': [],
+  };
+}
+
+function buildRandomTxData(fwConstants) {
+  const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
   for (let i = 0; i < numRandom; i++) {
     const tx = {
-      nonce: Math.floor(Math.random() * 16000),
-      gasPrice: ETH_GAS_PRICE_MIN + Math.floor(Math.random() * (ETH_GAS_PRICE_MAX - ETH_GAS_PRICE_MIN)),
-      gasLimit: ETH_GAS_LIMIT_MIN + Math.floor(Math.random() * (ETH_GAS_LIMIT_MAX - ETH_GAS_LIMIT_MIN)),
-      value: Math.floor(Math.random() * 10**Math.floor(Math.random()*30)),
+      nonce: randInt(16000),
+      gasPrice: ETH_GAS_PRICE_MIN + randInt(ETH_GAS_PRICE_MAX - ETH_GAS_PRICE_MIN),
+      gasLimit: ETH_GAS_LIMIT_MIN + randInt(ETH_GAS_LIMIT_MAX - ETH_GAS_LIMIT_MIN),
+      value: randInt(10**randInt(30)),
       to: `0x${crypto.randomBytes(20).toString('hex')}`,
-      data: `0x${crypto.randomBytes(Math.floor(Math.random() * 100)).toString('hex')}`,
+      data: `0x${crypto.randomBytes(randInt(maxDataSz)).toString('hex')}`,
+      eip155: randInt(2) > 0 ? true : false,
+      // 51 is the max bit size that we can validate with our bignum lib (see chainID section)
+      _network: getChainId(randInt(52), 0), 
     }
     randomTxData.push(tx);
   }
@@ -64,9 +91,9 @@ function buildRandomTxData() {
 function buildRandomMsg(type='signPersonal') {
   if (type === 'signPersonal') {
     // A random string will do
-    const isHexStr = Math.random() > 0.5;
+    const isHexStr = randInt(2) > 0 ? true : false;
     const fwConstants = constants.getFwVersionConst(client.fwVersion);
-    const L = Math.floor(Math.random() * (fwConstants.ethMaxDataSz - MSG_PAYLOAD_METADATA_SZ));
+    const L = randInt(fwConstants.ethMaxDataSz - MSG_PAYLOAD_METADATA_SZ);
     if (isHexStr)
       return `0x${crypto.randomBytes(L).toString('hex')}`; // Get L hex bytes (represented with a string with 2*L chars)
     else
@@ -179,7 +206,7 @@ describe('Setup client', () => {
     const fwConstants = constants.getFwVersionConst(client.fwVersion);
     ETH_GAS_PRICE_MAX = fwConstants.ethMaxGasPrice;
     // Build the random transactions
-    buildRandomTxData();
+    buildRandomTxData(fwConstants);
   });
 })
 
@@ -193,26 +220,12 @@ if (!process.env.skip) {
     it('Should test range of chainId sizes and EIP155 tag', async () => {
       const txData = JSON.parse(JSON.stringify(defaultTxData));
       // Add some random data for good measure, since this will interact with the data buffer
-      txData.data = `0x${crypto.randomBytes(Math.floor(Math.random() * 100)).toString('hex')}`;
+      txData.data = `0x${crypto.randomBytes(randInt(100)).toString('hex')}`;
 
       // Custom chains need to be fully defined for EthereumJS's Common module
       // Here we just define a dummy chain. It isn't used for anything, but is required
       // for us to verify the output transaction payload against EthereumJS-TX (reference impl)
-      const chain = {
-        'name': 'myFakeChain',
-        'chainId': 0,
-        'networkId': 0,
-        'genesis': {},
-        'hardforks': [],
-        'bootstrapNodes': [],
-      };
-
-      // Test boundaries for chainId sizes. We allow chainIds up to MAX_UINT64, but
-      // the mechanism to test is different for chainIds >254.
-      // NOTE: All unknown chainIds lead to using EIP155 (which includes all of these)
-      function getChainId(pow, add) {
-        return `0x${new BN(2).pow(pow).plus(add).toString(16)}`
-      }
+      const chain = getFakeChain();
 
       // This one can fit in the normal chainID u8
       chain.chainId = chain.networkId = getChainId(8, -2); // 254
@@ -262,13 +275,23 @@ if (!process.env.skip) {
       await testTxPass(buildTxReq(txData, numChainId), chain);
 
       // Test boundary of new dataSz
-      chain.chainId = chain.networkId = getChainId(51, 0); // UINT64_MAX should pass
+      chain.chainId = chain.networkId = getChainId(51, 0); // 8 byte id
+      // 8 bytes for the id itself and 1 byte for chainIdSz. This data is serialized into the request payload.
+      let chainIdSz = 9;
       const fwConstants = constants.getFwVersionConst(client.fwVersion);
-      const maxDataSz = fwConstants.ethMaxDataSz - 9; // Subtract 8 bytes for chainID and 1 byte for chainIdSz
-      txData.data = `0x${crypto.randomBytes(Math.floor(Math.random() * maxDataSz)).toString('hex')}`;
+      const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
       await testTxPass(buildTxReq(txData, chain.chainId), chain);
-      txData.data = `0x${crypto.randomBytes(Math.floor(Math.random() * maxDataSz+1)).toString('hex')}`;
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
       await testTxFail(buildTxReq(txData, chain.chainId), chain);
+      // Also test smaller sizes
+      chain.chainId = chain.networkId = getChainId(16, -1);
+      chainIdSz = 3;
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
+      await testTxPass(buildTxReq(txData, chain.chainId), chain);
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
+      await testTxFail(buildTxReq(txData, chain.chainId), chain);
+
     })
 
     it('Should test range of `value`', async () => {
@@ -308,13 +331,15 @@ if (!process.env.skip) {
         return s;
       }
       const fwConstants = constants.getFwVersionConst(client.fwVersion);
-      txData.data = buildDataStr(1, fwConstants.ethMaxDataSz - 1)
+      const maxDataSz = fwConstants.ethMaxDataSz + (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
+
+      txData.data = buildDataStr(1, maxDataSz - 1)
       await testTxPass(buildTxReq(txData))
-      txData.data = buildDataStr(2, fwConstants.ethMaxDataSz)  
+      txData.data = buildDataStr(2, maxDataSz)  
       await testTxPass(buildTxReq(txData))
 
       // Expected failures
-      txData.data = buildDataStr(3, fwConstants.ethMaxDataSz + 1)
+      txData.data = buildDataStr(3, maxDataSz + 1)
       await testTxFail(buildTxReq(txData))
     });
 
@@ -409,7 +434,6 @@ if (!process.env.skip) {
       // For non-EIP155 transactions, we expect `v` to be 27 or 28
       expect(res.sig.v.toString('hex')).to.oneOf([(27).toString(16), (28).toString(16)])
     });
-
   });
 }
 
@@ -418,12 +442,12 @@ describe('Test random transaction data', function() {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');
   })
 
-  it.each(randomTxDataLabels, 'Random transaction %s', ['label'], async function(n, next) {
+  it.each(randomTxDataLabels, 'Random transactions %s', ['label'], async function(n, next) {
     const txData = randomTxData[n.number];
-    const r = Math.round(Math.random())
-    const network = r === 1 ? 'rinkeby' : 'mainnet';
+    const chain = getFakeChain();
+    chain.chainId = chain.networkId = txData._network
     try {
-      await testTxPass(buildTxReq(txData, network))
+      await testTxPass(buildTxReq(txData, chain.chainId), chain)
       setTimeout(() => { next() }, 2500);
     } catch (err) {
       setTimeout(() => { next(err) }, 2500);

--- a/test/testUtil/helpers.js
+++ b/test/testUtil/helpers.js
@@ -22,7 +22,7 @@ exports.ETH_COIN = HARDENED_OFFSET+60;
 function setupTestClient(env) {
   const setup = {
     name: env.name || 'SDK Test',
-    baseUrl: 'https://signing.staging-gridpl.us',
+    baseUrl: env.baseUrl || 'https://signing.staging-gridpl.us',
     crypto,
     timeout: 120000,
   };


### PR DESCRIPTION
Adds support for expanded message sizes in the signTransaction route. Corresponds to changes in Lattice firmware.

* If data is too large to fit in a single request, we can now split it across multiple payloads
* Uses the same `tmpReqCode` chaining mechanism used in `addAbi` to sequence multiple requests
* Updates Ethereum transactions tests to incorporate this added complexity