### PR TITLE
Adds mechanism to catch ASCII string buffers in personal_sign

### DIFF
--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -46,8 +46,15 @@ exports.buildEthereumMsgRequest = function(input) {
       // If this is a buffer and the user has specified whether or not this
       // is a hex buffer with the optional argument, write that
       displayHex = input.displayHex
+    } else {
+      // Otherwise, determine if this buffer is an ASCII string. If it is, set `displayHex` accordingly.
+      // NOTE: THIS MEANS THAT NON-ASCII STRINGS WILL DISPLAY AS HEX SINCE WE CANNOT KNOW IF THE REQUESTER
+      //        EXPECTED NON-ASCII CHARACTERS TO DISPLAY IN A STRING
+      // TODO: Develop a more elegant solution for this
+      if (!input.payload.toString)
+        throw new Error('Unsupported input data type');
+      displayHex = false === isASCIIStr(input.payload.toString())
     }
-
     // Flow data into extraData requests, which will follow-up transaction requests, if supported/applicable    
     const extraDataPayloads = [];
     if (payload.length > MAX_BASE_MSG_SZ) {
@@ -357,6 +364,10 @@ function writeUInt64BE(n, buf, off) {
 
 function isHexStr(str) {
   return (/^[0-9a-fA-F]+$/).test(str)
+}
+
+function isASCIIStr(str) {
+  return (/^[\x00-\x7F]+$/).test(str)
 }
 
 // Determine if the Lattice can display a string we give it. Currently, the Lattice can only

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -468,6 +468,15 @@ describe('Test ETH personalSign', function() {
     await testMsg(buildMsgReq(msg2, protocol), false);
   })
 
+  it('Should test ASCII buffers', async () => {
+    await testMsg(buildMsgReq(Buffer.from('i am an ascii buffer'), 'signPersonal'), true);
+    await testMsg(buildMsgReq(Buffer.from('{\n\ttest: foo\n}'), 'signPersonal'), false);
+  })
+
+  it('Should test hex buffers', async () => {
+    await testMsg(buildMsgReq(Buffer.from('abcdef', 'hex'), 'signPersonal'), true);
+  })
+
   it('Msg: sign_personal boundary conditions', async () => {
     const protocol = 'signPersonal';
     const fwConstants = constants.getFwVersionConst(client.fwVersion);


### PR DESCRIPTION
We were previously only setting `displayHex=false` when we got a string, but
we also need to account for ASCII strings that are passed as buffers. This adds
a mechanism to handle that case.
Note that we are still limited by not being able to display non-ASCII string
characters, so emoji-laden strings will still get converted to hex. We should
eventually find a way around that...
Fixes #138