### PR TITLE
Reverts ETH_MSG response sig to again return `v` as a buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -94,10 +94,7 @@ exports.validateEthereumMsgResponse = function(res, req) {
     );
     // NOTE: We are currently hardcoding networkID=1 and useEIP155=false but these
     //       may be configurable in future versions
-    const recoveredSig = addRecoveryParam(Buffer.concat([prefix, msg]), sig, signer, 1, false)
-    // `personal_sign` requesters want the `v` value as a number or they will parse it as NaN
-    recoveredSig.v = Number(`0x${recoveredSig.v.toString('hex')}`)
-    return recoveredSig;
+    return addRecoveryParam(Buffer.concat([prefix, msg]), sig, signer, 1, false)
   } else {
     throw new Error('Unsupported protocol');
   }


### PR DESCRIPTION
a1d2679 was a hotfix to return an acceptable value for `v` in ETH_MSG responses.
The conversion from a buffer to an integer should be done in the `eth-lattice-keyring`
module instead of the SDK. The SDK should return the same signature types for ALL
signature requests, which means `v` as a buffer.