### PR TITLE
Remove javascript numbers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -159,9 +159,9 @@ Ethereum transactions consist of six fields. An example payload looks as follows
 
 ```
 const data = {
-    nonce: 1,
-    gasLimit: 25000,
-    gasPrice: 1000000000,
+    nonce: '0x01',
+    gasLimit: '0x61a8,
+    gasPrice: '0x2540be400,
     to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
     value: 0,
     data: '0x12345678'
@@ -178,14 +178,14 @@ const signOpts = {
 
 | Param      | Type      | Restrictions       |        
 |:-----------|:----------|:-------------------|
-| `nonce`    | number    | None               |
-| `gasLimit` | number    | Must be >=22000    |
-| `gasPrice` | number    | Must be >0         |
-| `to`       | string    | Must be 20 bytes (excluding optional `0x` prefix) |
-| `value`    | number or hex string    | None               |
-| `data`     | string    | Must be <557 bytes |
+| `nonce`    | hex string or number    | None               |
+| `gasLimit` | hex string or number    | Must be >=22000    |
+| `gasPrice` | hex string or number    | Must be >0         |
+| `to`       | hex string    | Must be 20 bytes (excluding optional `0x` prefix) |
+| `value`    | hex string or number    | None               |
+| `data`     | hex string    | Must be <557 bytes |
 | `signerPath`| Array | Address path from which to sign this transaction. NOTE: Ethereum wallets typically use the path specified in the example above for all transactions. |
-| `chainId`  | string/number    | Can be hex string, number, or name. See name options below. Default=`mainnet` |
+| `chainId`  | hex string or number    | Can be hex string, number, or name. See name options below. Default=`mainnet` |
 | `eip155` | bool    | Optional. Set the value you want to override the default EIP155 usage of the given chain (see below) |
 
 #### Chain ID
@@ -196,9 +196,9 @@ The `chainId` param is used to provide replay protectin for most Ethereum-based 
 2. An integer (only recommended for small numbers -- see below section)
 3. A hex string (e.g. `0x1234`)
 
-**Note about using large integers for `chainId`**
+**Hex strings are strongly recommended**
 
-Generally, we recommend *not* using a javascript integer if you have a large `chainId` , as it may not be correctly represented by a number in javascript. Consider the following dummy code in `node.js`:
+Generally, we recommend **not** using Javascript integers and **never** using them for fields that may contain large values, such as `value` (which is measured in units of wei, where 10**18 wei = 1 ether). We recommend using hex strings instead, as shown in the example above. Consider the following dummy code in `node.js`:
 
 ```
 > new bn(2).pow(64).toString(16)
@@ -215,7 +215,9 @@ Generally, we recommend *not* using a javascript integer if you have a large `ch
 '10000000000000180'
 ```
 
-As you can see, all sorts of problems arise from large javascript integers. Don't use them!
+As you can see, all sorts of problems arise from large Javascript integers. Don't use them!
+
+Note that in the `gridplus-sdk`, all numerical inputs are converted to big numbers, but we still recommend avoiding them.
 
 **"Named" `chainId`s**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -150,12 +150,12 @@ describe('Connect and Pair', () => {
     const GAS_LIMIT_MAX = 12500000;
     
     const txData = {
-      nonce: 0,
-      gasPrice: 1200000000,
-      gasLimit: 50000,
-      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
-      value: 100,
-      data: null
+      nonce: '0x02',
+      gasPrice: '0x1fe5d61a00',
+      gasLimit: '0x034e97',
+      to: '0x1af768c0a217804cfe1a0fb739230b546a566cd6',
+      value: '0x01cba1761f7ab9870c',
+      data: '0x17e914679b7e160613be4f8c2d3203d236286d74eb9192f6d6f71b9118a42bb033ccd8e8'
     };
     const req = {
       currency: 'ETH',

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -300,11 +300,12 @@ if (!process.env.skip) {
       await testTxPass(buildTxReq(txData))
       txData.value = 1234;
       await testTxPass(buildTxReq(txData))
-      txData.value = 10**14;
+      txData.value = `0x${new BN('10e14').toString(16)}`;
       await testTxPass(buildTxReq(txData))
-      txData.value = 10**64;
-      await testTxPass(buildTxReq(txData))
-      txData.value = 10**77;
+      txData.value = `0x${new BN('10e64').toString(16)}`;
+      await testTxPass(buildTxReq(txData))      
+      txData.value = `0x${new BN('1e77').minus(1).toString(16)}`;
+      console.log('tx.value', txData.value)
       await testTxPass(buildTxReq(txData))
       txData.value = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
       await testTxPass(buildTxReq(txData))
@@ -434,6 +435,7 @@ if (!process.env.skip) {
       // For non-EIP155 transactions, we expect `v` to be 27 or 28
       expect(res.sig.v.toString('hex')).to.oneOf([(27).toString(16), (28).toString(16)])
     });
+
   });
 }
 


### PR DESCRIPTION
These changes takes steps to avoid using Javascript numbers when building ETH transactions. We now force all numerical, non-buffer inputs into `bignumber.js` objects before converting to hex buffers. This avoids the possibility of mutating large numerical inputs.