### PR TITLE
Support variable HD path lengths

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -219,8 +219,18 @@ function getFwVersionConst(v) {
         c.addrFlagsAllowed = false;
         return c;
     } 
-    if (gte(v, [0, 10, 4])) {
-        // >=0.10.3
+    if (gte(v, [0, 10, 5])) {
+        // >=0.10.5
+        c.flexibleAddrPaths = true;
+        c.reqMaxDataSz = 1678;
+        c.ethMaxDataSz = c.reqMaxDataSz - 128;
+        c.ethMaxMsgSz = c.ethMaxDataSz;
+        c.ethMaxGasPrice = 20000000000000; // 20000 gwei
+        c.addrFlagsAllowed = true;
+        c.extraDataFrameSz = 1500; // 1500 bytes per frame of extraData allowed
+        c.extraDataMaxFrames = 1;  // 1 frame of extraData allowed
+    } else if (gte(v, [0, 10, 4])) {
+        // >=0.10.4
         c.reqMaxDataSz = 1678;
         c.ethMaxDataSz = c.reqMaxDataSz - 128;
         c.ethMaxMsgSz = c.ethMaxDataSz;

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -61,7 +61,7 @@ exports.buildEthereumTxRequest = function(data) {
   try {
     let { chainId=1 } = data;
     const { signerPath, eip155=null, fwConstants } = data;
-    const { ethMaxDataSz, extraDataFrameSz, extraDataMaxFrames, flexibleAddrPaths } = fwConstants;
+    const { ethMaxDataSz, extraDataFrameSz, extraDataMaxFrames } = fwConstants;
     const EXTRA_DATA_ALLOWED = extraDataFrameSz > 0 && extraDataMaxFrames > 0;
     const MAX_BASE_DATA_SZ = ethMaxDataSz;
     // Sanity checks:
@@ -235,7 +235,8 @@ function stripZeros(a) {
 exports.buildEthRawTx = function(tx, sig, address, useEIP155=true) {
   // RLP-encode the data we sent to the lattice
   const rlpEncoded = rlp.encode(tx.rawTx);
-  const newSig = addRecoveryParam(rlpEncoded, sig, address, tx.chainId, useEIP155);
+  const hash = Buffer.from(keccak256(rlpEncoded), 'hex')
+  const newSig = addRecoveryParam(hash, sig, address, tx.chainId, useEIP155);
   // Use the signature to generate a new raw transaction payload
   const newRawTx = tx.rawTx.slice(0, 6);
   newRawTx.push(newSig.v);

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -60,6 +60,7 @@ describe('Connect and Pair', () => {
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);
     if (caughtErr === false) {
+      const fwConstants = constants.getFwVersionConst(client.fwVersion)
       const addrData = { 
         currency: 'BTC', 
         startPath: [helpers.BTC_PURPOSE_P2SH_P2WPKH, helpers.BTC_COIN, HARDENED_OFFSET, 0, 0], 
@@ -81,6 +82,28 @@ describe('Connect and Pair', () => {
       addrs = await helpers.getAddresses(client, addrData, 2000);
       expect(addrs.length).to.equal(1);
       expect(addrs[0].slice(0, 2)).to.equal('0x');
+
+      // If firmware supports it, try shorter paths
+      if (fwConstants.flexibleAddrPaths) {
+        const flexData = { 
+          currency: 'ETH', 
+          startPath: [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0], 
+          n: 1,
+          skipCache: true,
+        }
+        addrs = await helpers.getAddresses(client, flexData, 2000);
+        expect(addrs.length).to.equal(1);
+        expect(addrs[0].slice(0, 2)).to.equal('0x')
+        // Should fail to fetch this if skipCache = false because this is not
+        // a supported asset's parent path
+        flexData.skipCache = false
+        try {
+          addrs = await helpers.getAddresses(client, flexData, 2000);
+          expect(addrs).to.equal(null)
+        } catch (err) {
+          expect(err).to.not.equal(null)
+        }
+      }
 
       // Bitcoin testnet
       addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -140,22 +140,6 @@ async function testTxFail(req) {
   }
 }
 
-async function testMsg(req, pass=true) {
-  try {
-    const sig = await helpers.sign(client, req);
-    // Validation happens already in the client
-    if (pass === true)
-      expect(sig.sig).to.not.equal(null);
-    else
-      expect(sig.sig).to.equal(null);
-  } catch (err) {
-    if (pass === true)
-      expect(err).to.equal(null);
-    else
-      expect(err).to.not.equal(null);
-  }
-}
-
 // Determine the number of random transactions we should build
 if (process.env.N)
   numRandom = parseInt(process.env.N);

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -16,7 +16,6 @@
 //        root CMakeLists.txt file (for dev units)
 require('it-each')({ testPerIteration: true });
 const BN = require('bignumber.js');
-const randomWords = require('random-words');
 const crypto = require('crypto');
 const EthTx = require('ethereumjs-tx').Transaction;
 const constants = require('./../src/constants')
@@ -33,7 +32,6 @@ let ETH_GAS_PRICE_MAX;                  // value depends on firmware version
 const ETH_GAS_LIMIT_MIN = 22000;        // Ether transfer (smallest op) is 22k gas
 const ETH_GAS_LIMIT_MAX = 12500000;     // 10M is bigger than the block size
 const ETH_GAS_PRICE_MIN = 1000000;      // 1,000,000 = 0.001 GWei - minimum
-const MSG_PAYLOAD_METADATA_SZ = 28;     // Metadata that must go in ETH_MSG requests
 const defaultTxData = {
   nonce: 0,
   gasPrice: 1200000000,
@@ -88,44 +86,13 @@ function buildRandomTxData(fwConstants) {
   }
 }
 
-function buildRandomMsg(type='signPersonal') {
-  if (type === 'signPersonal') {
-    // A random string will do
-    const isHexStr = randInt(2) > 0 ? true : false;
-    const fwConstants = constants.getFwVersionConst(client.fwVersion);
-    const L = randInt(fwConstants.ethMaxDataSz - MSG_PAYLOAD_METADATA_SZ);
-    if (isHexStr)
-      return `0x${crypto.randomBytes(L).toString('hex')}`; // Get L hex bytes (represented with a string with 2*L chars)
-    else
-      return randomWords({ exactly: L, join: ' ' }).slice(0, L); // Get L ASCII characters (bytes)
-  } else if (type === 'eip712') {
-    return helpers.buildRandomEip712Object(randInt);
-  }
-}
-
-<<<<<<< HEAD
 function buildTxReq(txData, network='mainnet', signerPath=[helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0]) {
-=======
-
-function buildTxReq(txData, network='mainnet') {
->>>>>>> 1c61069ea9285c03ca86ed4bc127f267eb4c0538
   return {
     currency: 'ETH',
     data: {
       signerPath,
       ...txData,
       chainId: network
-    }
-  }
-}
-
-function buildMsgReq(payload, protocol, signerPath=[helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0]) {
-  return {
-    currency: 'ETH_MSG',
-    data: {
-      signerPath,
-      payload,
-      protocol,
     }
   }
 }

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -218,13 +218,16 @@ if (!process.env.skip) {
     })
 
     it('Should test and validate signatures from shorter derivation paths', async () => {
-      // m/44'/60'/0'/x
-      const path = [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0];
-      const txData = JSON.parse(JSON.stringify(defaultTxData));
-      await testTxPass(buildTxReq(txData, 'mainnet', path));
-      await testTxPass(buildTxReq(txData, 'mainnet', path.slice(0, 3)));      
-      await testTxPass(buildTxReq(txData, 'mainnet', path.slice(0, 2)));
-      await testTxFail(buildTxReq(txData, 'mainnet', path.slice(0, 1)));            
+      const fwConstants = constants.getFwVersionConst(client.fwVersion)
+      if (fwConstants.flexibleAddrPaths) {
+        // m/44'/60'/0'/x
+        const path = [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0];
+        const txData = JSON.parse(JSON.stringify(defaultTxData));
+        await testTxPass(buildTxReq(txData, 'mainnet', path));
+        await testTxPass(buildTxReq(txData, 'mainnet', path.slice(0, 3)));      
+        await testTxPass(buildTxReq(txData, 'mainnet', path.slice(0, 2)));
+        await testTxFail(buildTxReq(txData, 'mainnet', path.slice(0, 1)));            
+      }
     })
 
     it('Should test range of chainId sizes and EIP155 tag', async () => {


### PR DESCRIPTION
Adds support for HD paths with <5 indices. We support paths between 2-5 indices long now. Corresponds to firmware changes in v0.10.5.