### PR TITLE
Adds shim to ensure we are using `borc` compatible bignumber objects.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -622,7 +622,13 @@ function parseEIP712Item(data, type, isEthers=false) {
     } else {
       // `bignumber.js` is needed for `cbor` encoding, which gets sent to the Lattice and plays
       // nicely with its firmware cbor lib.
-      data = new BN(ensureHexBuffer(data).toString('hex'), 16)
+      // NOTE: If we instantiate a `bignumber.js` object, it will not match what `borc` creates
+      // when run inside of the browser (i.e. MetaMask). Thus we introduce this hack to make sure
+      // we are creating a compatible type.
+      // TODO: Find another cbor lib that is compataible with the firmware's lib in a browser
+      // context. This is surprisingly difficult - I tried several libs and only cbor/borc have
+      // worked (borc is a supposedly "browser compatible" version of cbor)
+      data = new cbor.Encoder().semanticTypes[1][0](ensureHexBuffer(data).toString('hex'), 16)
     }
   } else if (type === 'bool') {
     // Booleans need to be cast to a u8

--- a/test/testEthMsg.js
+++ b/test/testEthMsg.js
@@ -165,7 +165,90 @@ describe('Test ETH EIP712', function() {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');
   })
 
-  it('Should test canonical EIP712 example', async () => {
+  it('Should get an error when the domain is too large', async () => {   
+    // Only 6 lines of text are allowed in the domain region and address types
+    // take 2 lines each. This is a firmware limitation to avoid overrunning the
+    // viewable text region
+    const msg = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+          { name: 'foo', type: 'address' },
+        ],
+        Mail: [
+          { name: 'contents', type: 'string' }
+        ]
+      },
+      primaryType: 'Mail',
+      domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 12,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+        foo: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccD',
+      },
+      message: {
+        contents: 'foobar'
+      }
+    };
+    const req = {
+      currency: 'ETH_MSG',
+      data: {
+        signerPath: [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0],
+        protocol: 'eip712',
+        payload: msg,
+      }
+    }
+    try {
+      await helpers.sign(client, req);
+    } catch (err) {
+      expect(err).to.not.equal(null)
+    }
+  })
+
+  it('Should test simple dydx example', async () => {
+    const msg = {
+      'types': {
+        'EIP712Domain': [
+          { 'name':'name', 'type':'string'},
+          {'name':'version', 'type':'string'},
+          {'name':'chainId', 'type':'uint256'}
+        ],
+        'dYdX':[
+          {'type':'string','name':'action'},
+          {'type':'string','name':'onlySignOn'}
+        ]
+      },
+      'domain':{
+        'name':'dYdX',
+        'version':'1.0',
+        'chainId':'1'
+      },
+      'primaryType': 'dYdX',
+      'message': {
+        'action': 'dYdX STARK Key',
+        'onlySignOn': 'https://trade.dydx.exchange'
+      }
+    }
+    const req = {
+      currency: 'ETH_MSG',
+      data: {
+        signerPath: [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0],
+        protocol: 'eip712',
+        payload: msg,
+      }
+    }
+    try {
+      await helpers.sign(client, req);
+    } catch (err) {
+      expect(err).to.equal(null)
+    }
+  })
+
+  it('Should test canonical EIP712 example', async () => {   
     const msg = {
       types: {
         EIP712Domain: [
@@ -598,10 +681,7 @@ describe('Test ETH EIP712', function() {
       'domain': {
         'name': 'Domain_Census_liberty_own_s',
         'version': '1',
-        'chainId': {
-          'type': 'BigNumber',
-          'hex': '0x2207'
-        },
+        'chainId': '0x2207',
         'verifyingContract': '0x52a3e01d76d2670f8fd452564b3f56eea6fc798d'
       },
       'message': {


### PR DESCRIPTION
The types do not compare properly in web environments like MetaMask, so
I have to use this hack to ensure we are using the correct object instantiator.
Also adds a few more EIP712 tests