### PR TITLE
Pre-computes ETH tx hash if data is too large to fit in the Lattice

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -268,6 +268,11 @@ function getFwVersionConst(v) {
     }
     // Very old legacy versions do not give a version number
     const legacy = (v.length === 0);
+    // V0.10.8 allows a user to sign a prehashed transaction if the payload
+    // is too big
+    if (!legacy && gte(v, [0, 10, 8])) {
+        c.prehashAllowed = true;
+    }
     // V0.10.5 added the ability to use flexible address path sizes, which
     // changes the `getAddress` API. It also added support for EIP712
     if (!legacy && gte(v, [0, 10, 5])) {

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -282,13 +282,10 @@ describe('Connect and Pair', () => {
     req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
     tx = await(helpers.sign(client, req));
     expect(tx.tx).to.not.equal(null);
+    question('Please ACCEPT the following transaction only if the warning screen displays. Press enter to continue.')
     req.data.data = client.crypto.randomBytes(maxDataSz+1).toString('hex');
-    try {
-      tx = await(helpers.sign(client, req));
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
+    tx = await(helpers.sign(client, req));
+    expect(tx.tx).to.not.equal(null);
     req.data.data = client.crypto.randomBytes(fwConstants.ethMaxDataSz).toString('hex');
     tx = await(helpers.sign(client, req));
     expect(tx.tx).to.not.equal(null);

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -16,7 +16,6 @@
 //        root CMakeLists.txt file (for dev units)
 require('it-each')({ testPerIteration: true });
 const BN = require('bignumber.js');
-const randomWords = require('random-words');
 const crypto = require('crypto');
 const EthTx = require('ethereumjs-tx').Transaction;
 const constants = require('./../src/constants')


### PR DESCRIPTION
This only applies to recent firmware versions and results in a different
warning screen on the Lattice telling the user that they are signing
a pre-computed hash and this can result in loss of funds.