### PR TITLE
Fixes issue introduced in v0.7.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",


### PR DESCRIPTION
In some cases we want hex buffers to represent `0` with a 0-length
buffer, and in others we want it represented as a 1-byte buffer `00`