### PR TITLE
Adds pre-hash optionality to Ethereum messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/constants.js
+++ b/src/constants.js
@@ -316,6 +316,11 @@ function getFwVersionConst(v) {
     }
     // Very old legacy versions do not give a version number
     const legacy = (v.length === 0);
+    // V0.10.10 allows a user to sign a prehashed ETH message if payload too big
+    if (!legacy && gte(v, [0, 10, 10])) {
+        c.ethMsgPreHashAllowed = true;
+    }
+
     // V0.10.8 allows a user to sign a prehashed transaction if the payload
     // is too big
     if (!legacy && gte(v, [0, 10, 8])) {


### PR DESCRIPTION
This corresponds to a small firmware release `v0.10.10`. It extends the pre-hash functionality used with ETH transactions to ETH messages (EIP712 and personal_sign).