### PR TITLE
EIP1559/2930 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -419,6 +419,15 @@
         "@ethersproject/strings": "^5.4.0"
       }
     },
+    "@types/bn.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -430,6 +439,24 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
       "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
       "dev": true
+    },
+    "@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "acorn": {
       "version": "8.0.4",
@@ -668,6 +695,12 @@
       "resolved": "https://registry.npmjs.org/bitwise/-/bitwise-2.0.4.tgz",
       "integrity": "sha512-ZOByl1Sc8SH2/owfRfR1apaC1ELNqHqAAtfqs1Ixqk/9Bod6VxWz10MiMYXkNiL95RdFAqOGQxm1TCGPf1iFyw=="
     },
+    "blakejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
+      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==",
+      "dev": true
+    },
     "bn.js": {
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
@@ -717,6 +750,20 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -743,6 +790,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
     },
     "call-bind": {
       "version": "1.0.0",
@@ -1446,6 +1499,68 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
+      "requires": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+      "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.4"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
+        "rlp": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+          "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "ethers": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.2.tgz",
@@ -1487,6 +1602,26 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethers-eip712/-/ethers-eip712-0.2.0.tgz",
       "integrity": "sha512-fgS196gCIXeiLwhsWycJJuxI9nL/AoUPGSQ+yvd+8wdWR+43G+J1n69LmWVWvAON0M6qNaf2BF4/M159U8fujQ=="
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "exit-on-epipe": {
       "version": "1.0.1",
@@ -1913,6 +2048,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+      "dev": true
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -2022,6 +2163,16 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "dev": true,
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
       }
     },
     "levn": {
@@ -2875,6 +3026,12 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -3006,6 +3163,15 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.27",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
+    "ethereumjs-util": "^7.1.0",
     "it-each": "^0.4.0",
     "lodash": ">=4.17.21",
     "minimist": ">=0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.7.27",
+  "version": "0.8.0",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/client.js
+++ b/src/client.js
@@ -742,7 +742,7 @@ class Client {
       const sig = parseDER(res.slice(off, (off + 2 + res[off + 1]))); off += DERLength;
       const ethAddr = res.slice(off, off + 20);
       // Determine the `v` param and add it to the sig before returning
-      const rawTx = ethereum.buildEthRawTx(req, sig, ethAddr, req.useEIP155);
+      const rawTx = ethereum.buildEthRawTx(req, sig, ethAddr);
       returnData.data = {
         tx: `0x${rawTx}`,
         txHash: `0x${ethereum.hashTransaction(rawTx)}`,

--- a/src/constants.js
+++ b/src/constants.js
@@ -273,6 +273,45 @@ function getFwVersionConst(v) {
     }
     // Very old legacy versions do not give a version number
     const legacy = (v.length === 0);
+
+    // BASE FIELDS
+    //--------------------------------------
+
+    // Various size constants have changed on the firmware side over time and
+    // are captured here
+    if (!legacy && gte(v, [0, 10, 4])) {
+        // >=0.10.3
+        c.reqMaxDataSz = 1678;
+        c.ethMaxGasPrice = 20000000000000; // 20000 gwei
+        c.addrFlagsAllowed = true;
+    } else if (!legacy && gte(v, [0, 10, 0])) {
+        // >=0.10.0
+        c.reqMaxDataSz = 1678;
+        c.ethMaxGasPrice = 20000000000000; // 20000 gwei
+        c.addrFlagsAllowed = true;
+    } else {
+        // Legacy or <0.10.0
+        c.reqMaxDataSz = 1152;
+        c.ethMaxGasPrice = 500000000000; // 500 gwei
+        c.addrFlagsAllowed = false;
+    }
+    // These transformations apply to all versions
+    c.ethMaxDataSz = c.reqMaxDataSz - 128;
+    c.ethMaxMsgSz = c.ethMaxDataSz;
+
+    // EXTRA FIELDS ADDED IN LATER VERSIONS
+    //-------------------------------------
+
+    // V0.10.12 allows new ETH transaction types
+    if (!legacy && gte(v, [0, 10, 12])) {
+        c.allowedEthTxTypesVersion = 1;
+        c.allowedEthTxTypes = [
+            1, // eip2930
+            2, // eip1559
+        ]
+        c.totalExtraEthTxDataSz = 10;
+    }
+
     // V0.10.10 allows a user to sign a prehashed ETH message if payload too big
     if (!legacy && gte(v, [0, 10, 10])) {
         c.ethMsgPreHashAllowed = true;
@@ -295,30 +334,7 @@ function getFwVersionConst(v) {
         c.extraDataFrameSz = 1500; // 1500 bytes per frame of extraData allowed
         c.extraDataMaxFrames = 1;  // 1 frame of extraData allowed
     }
-    // Various size constants have changed on the firmware side over time and
-    // are captured here
-    if (!legacy && gte(v, [0, 10, 4])) {
-        // >=0.10.3
-        c.reqMaxDataSz = 1678;
-        c.ethMaxDataSz = c.reqMaxDataSz - 128;
-        c.ethMaxMsgSz = c.ethMaxDataSz;
-        c.ethMaxGasPrice = 20000000000000; // 20000 gwei
-        c.addrFlagsAllowed = true;
-    } else if (!legacy && gte(v, [0, 10, 0])) {
-        // >=0.10.0
-        c.reqMaxDataSz = 1678;
-        c.ethMaxDataSz = c.reqMaxDataSz - 128;
-        c.ethMaxMsgSz = c.ethMaxDataSz;
-        c.ethMaxGasPrice = 20000000000000; // 20000 gwei
-        c.addrFlagsAllowed = true;
-    } else {
-        // Legacy or <0.10.0
-        c.reqMaxDataSz = 1152;
-        c.ethMaxDataSz = c.reqMaxDataSz - 128;
-        c.ethMaxMsgSz = c.ethMaxDataSz;
-        c.ethMaxGasPrice = 500000000000; // 500 gwei
-        c.addrFlagsAllowed = false;
-    }
+
     return c;
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -303,7 +303,7 @@ function getFwVersionConst(v) {
     //-------------------------------------
 
     // V0.10.12 allows new ETH transaction types
-    if (!legacy && gte(v, [0, 10, 12])) {
+    if (!legacy && gte(v, [0, 11, 0])) {
         c.allowedEthTxTypesVersion = 1;
         c.allowedEthTxTypes = [
             1, // eip2930

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -46,7 +46,7 @@ exports.validateEthereumMsgResponse = function(res, req) {
     const hash =  prehash ? 
                   prehash : 
                   Buffer.from(keccak256(Buffer.concat([get_personal_sign_prefix(msg.length), msg])), 'hex');
-    return addRecoveryParam(hash, sig, signer, 1, false)
+    return addRecoveryParam(hash, sig, signer, { chainId: 1, useEIP155: false })
   } else if (input.protocol === 'eip712') {
     const digest = prehash ? prehash : eip712.TypedDataUtils.encodeDigest(req.input.payload);
     return addRecoveryParam(digest, sig, signer)
@@ -58,10 +58,10 @@ exports.validateEthereumMsgResponse = function(res, req) {
 exports.buildEthereumTxRequest = function(data) {
   try {
     let { chainId=1 } = data;
-    const { signerPath, eip155=null, fwConstants } = data;
+    const { signerPath, eip155=null, fwConstants, type=null } = data;
     const { extraDataFrameSz, extraDataMaxFrames, prehashAllowed } = fwConstants;
     const EXTRA_DATA_ALLOWED = extraDataFrameSz > 0 && extraDataMaxFrames > 0;
-    const MAX_BASE_DATA_SZ = fwConstants.ethMaxDataSz;
+    let MAX_BASE_DATA_SZ = fwConstants.ethMaxDataSz;
     const VAR_PATH_SZ = fwConstants.varAddrPathSzAllowed;
 
     // Sanity checks:
@@ -75,7 +75,16 @@ exports.buildEthereumTxRequest = function(data) {
     // Sanity check on signePath
     if (!signerPath) 
       throw new Error('`signerPath` not provided');
-
+    
+    // We support eip1559 and eip2930 types (as well as legacy)
+    const eip1559IsAllowed = (fwConstants.allowedEthTxTypes && 
+                              fwConstants.allowedEthTxTypes.indexOf(2) > -1);
+    const eip2930IsAllowed = (fwConstants.allowedEthTxTypes && 
+                              fwConstants.allowedEthTxTypes.indexOf(1) > -1);
+    const isEip1559 = (eip1559IsAllowed && (type === 2 || type === 'eip1559'));
+    const isEip2930 = (eip2930IsAllowed && (type === 1 || type === 'eip2930'));
+    if (type !== null && !isEip1559 && !isEip2930)
+      throw new Error('Unsupported Ethereum transaction type');
     // Determine if we should use EIP155 given the chainID.
     // If we are explicitly told to use eip155, we will use it. Otherwise,
     // we will look up if the specified chainId is associated with a chain
@@ -95,21 +104,60 @@ exports.buildEthereumTxRequest = function(data) {
     // Ensure all fields are 0x-prefixed hex strings
     const rawTx = [];
     // Build the transaction buffer array
+    const chainIdBytes = ensureHexBuffer(chainId);
     const nonceBytes = ensureHexBuffer(data.nonce);
-    const gasPriceBytes = ensureHexBuffer(data.gasPrice);
+    let gasPriceBytes = ensureHexBuffer(data.gasPrice);
     const gasLimitBytes = ensureHexBuffer(data.gasLimit);
     const toBytes = ensureHexBuffer(data.to);
     const valueBytes = ensureHexBuffer(data.value);
     const dataBytes = ensureHexBuffer(data.data);
+
+    if (isEip1559 || isEip2930) {
+      // EIP1559 and EIP2930 transactions have a chainID field
+      rawTx.push(chainIdBytes);
+    }
     rawTx.push(nonceBytes);
-    rawTx.push(gasPriceBytes);
+    let maxPriorityFeePerGasBytes, maxFeePerGasBytes;
+    if (isEip1559) {
+      if (!data.maxPriorityFeePerGas)
+        throw new Error('EIP1559 transactions must include `maxPriorityFeePerGas`');
+      if (!data.maxPriorityFeePerGas)
+        throw new Error('EIP1559 transactions must include `maxFeePerGas`');
+      maxPriorityFeePerGasBytes = ensureHexBuffer(data.maxPriorityFeePerGas);
+      rawTx.push(maxPriorityFeePerGasBytes);
+      maxFeePerGasBytes = ensureHexBuffer(data.maxFeePerGas);
+      rawTx.push(maxFeePerGasBytes);
+      // EIP1559 renamed "gasPrice" to "maxFeePerGas", but firmware still
+      // uses `gasPrice` in the struct, so update that value here.
+      gasPriceBytes = maxFeePerGasBytes;
+    } else {
+      // EIP1559 transactions do not have the gasPrice field
+      rawTx.push(gasPriceBytes);
+    }
     rawTx.push(gasLimitBytes);
     rawTx.push(toBytes);
     rawTx.push(valueBytes);
     rawTx.push(dataBytes);
+    // We do not currently support accessList in firmware so we need to prehash if
+    // the list is non-null
+    let PREHASH_FROM_ACCESS_LIST = false;
+    if (isEip1559 || isEip2930) {
+      const accessList = [];
+      if (Array.isArray(data.accessList)) {
+        data.accessList.forEach((listItem) => {
+          const keys = [];
+          listItem.storageKeys.forEach((key) => {
+            keys.push(ensureHexBuffer(key))
+          })
+          accessList.push([ ensureHexBuffer(listItem.address), keys ])
+          PREHASH_FROM_ACCESS_LIST = true;
+        })
+      }
+      rawTx.push(accessList);
+    }
     // Add empty v,r,s values
     if (useEIP155 === true) {
-      rawTx.push(ensureHexBuffer(chainId)); // v
+      rawTx.push(chainIdBytes); // v (which is the same as chainId in EIP155 txs)
       rawTx.push(ensureHexBuffer(null));    // r
       rawTx.push(ensureHexBuffer(null));    // s
     }
@@ -117,6 +165,13 @@ exports.buildEthereumTxRequest = function(data) {
     // 2. BUILD THE LATTICE REQUEST PAYLOAD
     //--------------
     const ETH_TX_NON_DATA_SZ = 122; // Accounts for metadata and non-data params
+    let ETH_TX_EXTRA_FIELDS_SZ = 0; // Accounts for newer ETH tx types (e.g. eip1559)
+    if (fwConstants.allowedEthTxTypesVersion === 1) {
+      // eip1559 and eip2930
+      // Add extra params and shrink the data region (extraData blocks are unaffected)
+      ETH_TX_EXTRA_FIELDS_SZ = fwConstants.totalExtraEthTxDataSz;
+      MAX_BASE_DATA_SZ -= ETH_TX_EXTRA_FIELDS_SZ;
+    }
     const txReqPayload = Buffer.alloc(MAX_BASE_DATA_SZ + ETH_TX_NON_DATA_SZ);
     let off = 0;
     // 1. EIP155 switch and chainID
@@ -141,7 +196,6 @@ exports.buildEthereumTxRequest = function(data) {
         throw new Error('Error parsing chainID');
       chainIdBuf.copy(txReqPayload, off); off += chainIdBuf.length;
     }
-
     // 2. Signer Path
     //------------------
     const signerPathBuf = buildSignerPathBuf(signerPath, VAR_PATH_SZ);
@@ -165,6 +219,29 @@ exports.buildEthereumTxRequest = function(data) {
     if (valueBytes.length > 32)
       throw new Error('Value too large');
     valueBytes.copy(txReqPayload, off + (32 - valueBytes.length)); off += 32;
+
+    // Extra Tx data comes before `data` in the struct
+    let PREHASH_UNSUPPORTED = false;
+    if (fwConstants.allowedEthTxTypesVersion === 1) {
+      // Some types may not be supported by firmware, so we will need to prehash
+      if (PREHASH_FROM_ACCESS_LIST) {
+        PREHASH_UNSUPPORTED = true;
+      }
+      txReqPayload.writeUint8(PREHASH_UNSUPPORTED === true, off); off += 1;  
+      // EIP1559 & EIP2930 struct version
+      if (isEip1559) {
+        txReqPayload.writeUint8(2, off); off += 1; // Eip1559 type enum value
+        if (maxPriorityFeePerGasBytes.length > 8)
+          throw new Error('maxPriorityFeePerGasBytes too large');
+        maxPriorityFeePerGasBytes.copy(txReqPayload, off + (8 - maxPriorityFeePerGasBytes.length)); off += 8;
+      } else if (isEip2930) {
+        txReqPayload.writeUint8(1, off); off += 1; // Eip2930 type enum value
+        off += fwConstants.totalExtraEthTxDataSz - 2; // Skip EIP1559 params
+      } else {
+        off += fwConstants.totalExtraEthTxDataSz - 1; // Skip EIP1559 and EIP2930 params
+      }
+    }
+
     // Flow data into extraData requests, which will follow-up transaction requests, if supported/applicable    
     const extraDataPayloads = [];
     let prehash = null;
@@ -183,11 +260,13 @@ exports.buildEthereumTxRequest = function(data) {
       } else {
         dataBytes.copy(dataToCopy, 0);
       }
-
-      if (prehashAllowed && totalSz > maxSzAllowed) {
+      if (prehashAllowed && (totalSz > maxSzAllowed || PREHASH_UNSUPPORTED)) {
         // If this payload is too large to send, but the Lattice allows a prehashed message, do that
         prehash = Buffer.from(keccak256(rlp.encode(rawTx)), 'hex')
+        console.log('prehash', prehash.toString('hex'))
+        console.log('prehash', new Uint8Array(prehash))
       } else {
+        console.log('frame splitting')
         if ((!EXTRA_DATA_ALLOWED) || (EXTRA_DATA_ALLOWED && totalSz > maxSzAllowed))
           throw new Error(`Data field too large (got ${dataBytes.length}; must be <=${maxSzAllowed-chainIdExtraSz} bytes)`);
         // Split overflow data into extraData frames
@@ -199,7 +278,9 @@ exports.buildEthereumTxRequest = function(data) {
         })
       }
     }
+
     // Write the data size (does *NOT* include the chainId buffer, if that exists)
+    console.log('dataBytes.length', dataBytes.length)
     txReqPayload.writeUInt16BE(dataBytes.length, off); off += 2;
     // Copy in the chainId buffer if needed
     if (chainIdBufSz > 0) {
@@ -215,6 +296,7 @@ exports.buildEthereumTxRequest = function(data) {
     }
     return {
       rawTx,
+      type,
       payload: txReqPayload.slice(0, off),
       extraDataPayloads,
       schema: constants.signingSchema.ETH_TRANSFER,  // We will use eth transfer for all ETH txs for v1 
@@ -239,23 +321,31 @@ function stripZeros(a) {
 
 // Given a 64-byte signature [r,s] we need to figure out the v value
 // and attah the full signature to the end of the transaction payload
-exports.buildEthRawTx = function(tx, sig, address, useEIP155=true) {
+exports.buildEthRawTx = function(tx, sig, address) {
   // RLP-encode the data we sent to the lattice
-  const rlpEncoded = rlp.encode(tx.rawTx);
+  let rlpEncoded = rlp.encode(tx.rawTx);
+  if (tx.type) {
+    rlpEncoded = Buffer.concat([Buffer.from([tx.type]), rlpEncoded])
+  }
   const hash = Buffer.from(keccak256(rlpEncoded), 'hex')
-  const newSig = addRecoveryParam(hash, sig, address, tx.chainId, useEIP155);
+  const newSig = addRecoveryParam(hash, sig, address, tx);
   // Use the signature to generate a new raw transaction payload
-  const newRawTx = tx.rawTx.slice(0, 6);
+  // Strip the last 3 items and replace them with signature components
+  const newRawTx = tx.useEIP155 ? tx.rawTx.slice(0, -3) : tx.rawTx;
   newRawTx.push(newSig.v);
   // Per `ethereumjs-tx`, RLP encoding should include signature components w/ stripped zeros
   // See: https://github.com/ethereumjs/ethereumjs-tx/blob/master/src/transaction.ts#L187
   newRawTx.push(stripZeros(newSig.r));
   newRawTx.push(stripZeros(newSig.s));
-  return rlp.encode(newRawTx).toString('hex');
+  let rlpEncodedWithSig = rlp.encode(newRawTx);
+  if (tx.type) {
+    rlpEncodedWithSig = Buffer.concat([Buffer.from([tx.type]), rlpEncodedWithSig])
+  }
+  return rlpEncodedWithSig.toString('hex');
 }
 
 // Attach a recovery parameter to a signature by brute-forcing ECRecover
-function addRecoveryParam(hashBuf, sig, address, chainId, useEIP155) {
+function addRecoveryParam(hashBuf, sig, address, txData={}) {
   try {
     // Rebuild the keccak256 hash here so we can `ecrecover`
     const hash = new Uint8Array(hashBuf);
@@ -268,14 +358,14 @@ function addRecoveryParam(hashBuf, sig, address, chainId, useEIP155) {
     let pubkey = secp256k1.ecdsaRecover(rs, v, hash, false).slice(1)
     // If the first `v` value is a match, return the sig!
     if (pubToAddrStr(pubkey) === address.toString('hex')) {
-      sig.v  = getRecoveryParam(v, useEIP155, chainId);
+      sig.v  = getRecoveryParam(v, txData);
       return sig;
     }
     // Otherwise, try the other `v` value
     v = 1;
     pubkey = secp256k1.ecdsaRecover(rs, v, hash, false).slice(1)
     if (pubToAddrStr(pubkey) === address.toString('hex')) {
-      sig.v  = getRecoveryParam(v, useEIP155, chainId);
+      sig.v  = getRecoveryParam(v, txData);
       return sig;
     } else {
       // If neither is a match, we should return an error
@@ -308,10 +398,18 @@ function fixLen(msg, length) {
 // Convert a 0/1 `v` into a recovery param:
 // * For non-EIP155 transactions, return `27 + v`
 // * For EIP155 transactions, return `(CHAIN_ID*2) + 35 + v`
-function getRecoveryParam(v, useEIP155, chainId=null) {
+function getRecoveryParam(v, txData={}) {
+  const { chainId, useEIP155, type } = txData;
   // If we are not using EIP155, convert v directly to a buffer and return it
   if (false === useEIP155 || chainId === null)
     return Buffer.from(new BN(v).plus(27).toString(16), 'hex');
+  // For EIP1559 and EIP2930 transactions, we want the recoveryParam (0 or 1)
+  // rather than the `v` value because the `chainId` is already included in the
+  // transaction payload.
+  if (type === 1 || type === 2) {
+    return ensureHexBuffer(v, true); // 0 or 1, with 0 expected as an empty buffer
+  }
+
   // We will use EIP155 in most cases. Convert v to a bignum and operate on it.
   // Note that the protocol calls for v = (CHAIN_ID*2) + 35/36, where 35 or 36
   // is decided on based on the ecrecover result. `v` is passed in as either 0 or 1

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -229,6 +229,7 @@ exports.buildEthereumTxRequest = function(data) {
     // Extra Tx data comes before `data` in the struct
     let PREHASH_UNSUPPORTED = false;
     if (fwConstants.allowedEthTxTypesVersion === 1) {
+      const extraEthTxDataSz = fwConstants.totalExtraEthTxDataSz || 0;
       // Some types may not be supported by firmware, so we will need to prehash
       if (PREHASH_FROM_ACCESS_LIST) {
         PREHASH_UNSUPPORTED = true;
@@ -242,9 +243,9 @@ exports.buildEthereumTxRequest = function(data) {
         maxPriorityFeePerGasBytes.copy(txReqPayload, off + (8 - maxPriorityFeePerGasBytes.length)); off += 8;
       } else if (isEip2930) {
         txReqPayload.writeUint8(1, off); off += 1; // Eip2930 type enum value
-        off += fwConstants.totalExtraEthTxDataSz - 2; // Skip EIP1559 params
+        off += extraEthTxDataSz - 2; // Skip EIP1559 params
       } else {
-        off += fwConstants.totalExtraEthTxDataSz - 1; // Skip EIP1559 and EIP2930 params
+        off += extraEthTxDataSz - 1; // Skip EIP1559 and EIP2930 params
       }
     }
 

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -56,7 +56,7 @@ describe('Connect and Pair', () => {
       expect(client.hasActiveWallet()).to.equal(true);
     }
   });
-
+/*
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);
     if (caughtErr === false) {
@@ -164,7 +164,7 @@ describe('Connect and Pair', () => {
       }
     }
   });
-
+*/
   it('Should sign Ethereum transactions', async () => {
     // Constants from firmware
     const fwConstants = constants.getFwVersionConst(client.fwVersion)
@@ -173,11 +173,15 @@ describe('Connect and Pair', () => {
     const GAS_LIMIT_MAX = 12500000;
     
     const txData = {
+      type: 'eip1559',
+      maxPriorityFeePerGas: 8,
+      maxFeePerGas: 9,
       nonce: '0x02',
       gasPrice: '0x1fe5d61a00',
       gasLimit: '0x034e97',
       to: '0x1af768c0a217804cfe1a0fb739230b546a566cd6',
-      value: '0x01cba1761f7ab9870c',
+      // value: '0x01cba1761f7ab9870c',
+      value: 3,
       data: '0x17e914679b7e160613be4f8c2d3203d236286d74eb9192f6d6f71b9118a42bb033ccd8e8'
     };
     const req = {
@@ -191,7 +195,7 @@ describe('Connect and Pair', () => {
     // Sign a tx that does not use EIP155 (no EIP155 on rinkeby for some reason)
     let tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
-
+/*
     // Sign a tx with EIP155
     req.data.chainId = 'mainnet';
     tx = await helpers.sign(client, req);
@@ -292,8 +296,9 @@ describe('Connect and Pair', () => {
     req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
     tx = await(helpers.sign(client, req));
     expect(tx.tx).to.not.equal(null);
+*/  
   });
-
+/*
   it('Should sign legacy Bitcoin inputs', async () => {  
     const txData = {
       prevOuts: [
@@ -453,5 +458,5 @@ describe('Connect and Pair', () => {
     expect(signResp.tx).to.not.equal(null);
 
   })
-
+*/
 });

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -56,7 +56,7 @@ describe('Connect and Pair', () => {
       expect(client.hasActiveWallet()).to.equal(true);
     }
   });
-/*
+
   it('Should get addresses', async () => {
     expect(caughtErr).to.equal(false);
     if (caughtErr === false) {
@@ -164,7 +164,7 @@ describe('Connect and Pair', () => {
       }
     }
   });
-*/
+
   it('Should sign Ethereum transactions', async () => {
     // Constants from firmware
     const fwConstants = constants.getFwVersionConst(client.fwVersion)
@@ -173,15 +173,11 @@ describe('Connect and Pair', () => {
     const GAS_LIMIT_MAX = 12500000;
     
     const txData = {
-      type: 'eip1559',
-      maxPriorityFeePerGas: 8,
-      maxFeePerGas: 9,
       nonce: '0x02',
       gasPrice: '0x1fe5d61a00',
       gasLimit: '0x034e97',
       to: '0x1af768c0a217804cfe1a0fb739230b546a566cd6',
-      // value: '0x01cba1761f7ab9870c',
-      value: 3,
+      value: '0x01cba1761f7ab9870c',
       data: '0x17e914679b7e160613be4f8c2d3203d236286d74eb9192f6d6f71b9118a42bb033ccd8e8'
     };
     const req = {
@@ -195,7 +191,7 @@ describe('Connect and Pair', () => {
     // Sign a tx that does not use EIP155 (no EIP155 on rinkeby for some reason)
     let tx = await helpers.sign(client, req);
     expect(tx.tx).to.not.equal(null);
-/*
+
     // Sign a tx with EIP155
     req.data.chainId = 'mainnet';
     tx = await helpers.sign(client, req);
@@ -296,9 +292,9 @@ describe('Connect and Pair', () => {
     req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
     tx = await(helpers.sign(client, req));
     expect(tx.tx).to.not.equal(null);
-*/  
+
   });
-/*
+
   it('Should sign legacy Bitcoin inputs', async () => {  
     const txData = {
       prevOuts: [
@@ -458,5 +454,5 @@ describe('Connect and Pair', () => {
     expect(signResp.tx).to.not.equal(null);
 
   })
-*/
+
 });

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -180,9 +180,42 @@ describe('Setup client', () => {
 })
 
 describe('Test new transaction types',  () => {
+  it('Should test eip1559 params', async () => {
+    const txData = {
+      type: 2,
+      maxFeePerGas: 1200000000,
+      maxPriorityFeePerGas: 1200000000,
+      nonce: 0,
+      gasLimit: 50000,
+      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
+      value: 100,
+      data: '0xdeadbeef',
+    };
+    // maxFeePerGas must be >= maxPriorityFeePerGas
+    await testTxPass(buildTxReq(txData))
+    txData.maxFeePerGas += 1;
+    await testTxPass(buildTxReq(txData))
+    txData.maxFeePerGas -= 2;
+    await testTxFail(buildTxReq(txData))
+  })
+
+  it('Should test eip1559 on a non-EIP155 network', async () => {
+    const txData = {
+      type: 2,
+      maxFeePerGas: 1200000000,
+      maxPriorityFeePerGas: 1000,
+      nonce: 0,
+      gasPrice: 1200000000,
+      gasLimit: 50000,
+      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
+      value: 100,
+      data: '0xdeadbeef',
+    };
+    await testTxPass(buildTxReq(txData), 4)
+  })
+
   it('Should test eip1559 with no access list', async () => {
     const txData = {
-      chainId: 1,
       type: 2,
       maxFeePerGas: 1200000000,
       maxPriorityFeePerGas: 1000,
@@ -198,7 +231,6 @@ describe('Test new transaction types',  () => {
 
   it('Should test eip1559 with an access list (should pre-hash)', async () => {
     const txData = {
-      chainId: 1,
       type: 2,
       maxFeePerGas: 1200000000,
       maxPriorityFeePerGas: 1000,
@@ -226,7 +258,6 @@ describe('Test new transaction types',  () => {
 
   it('Should test eip2930 with no access list', async () => {
     const txData = {
-      chainId: 1,
       type: 1,
       nonce: 0,
       gasPrice: 1200000000,
@@ -240,7 +271,6 @@ describe('Test new transaction types',  () => {
 
   it('Should test eip2930 with an access list (should pre-hash)', async () => {
     const txData = {
-      chainId: 1,
       type: 1,
       nonce: 0,
       gasPrice: 1200000000,
@@ -263,8 +293,9 @@ describe('Test new transaction types',  () => {
     };
     await testTxPass(buildTxReq(txData))
   })
+
 })
-/*
+
 if (!process.env.skip) {
   describe('Test ETH Tx Params', () => {
     beforeEach(() => {
@@ -499,4 +530,3 @@ describe('Test random transaction data', function() {
     }
   })
 })
-*/

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -112,6 +112,8 @@ async function testTxPass(req) {
     txData.maxFeePerGas = req.data.maxFeePerGas;
   if (req.data.maxPriorityFeePerGas)
     txData.maxPriorityFeePerGas = req.data.maxPriorityFeePerGas;
+  if (req.data.accessList)
+    txData.accessList = req.data.accessList;
   const sigData = {
     v: parseInt(`0x${tx.sig.v.toString('hex')}`),
     r: `0x${tx.sig.r}`,
@@ -142,7 +144,6 @@ async function testTxFail(req) {
   try {
     tx = await helpers.sign(client, req);
   } catch (err) {
-    console.log('err', err)
     expect(err).to.not.equal(null);
     return;
   }
@@ -177,7 +178,7 @@ describe('Setup client', () => {
     buildRandomTxData(fwConstants);
   });
 })
-/*
+
 describe('Test new transaction types',  () => {
   it('Should test eip1559 with no access list', async () => {
     const txData = {
@@ -190,48 +191,87 @@ describe('Test new transaction types',  () => {
       gasLimit: 50000,
       to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
       value: 100,
-      data: null,
+      data: '0xdeadbeef',
     };
     await testTxPass(buildTxReq(txData))
   })
 
-  // it('Should test eip1559 with an access list (should pre-hash)', async () => {
-  //   const txData = {
-  //     chainId: 1,
-  //     type: 2,
-  //     maxFeePerGas: 1200000000,
-  //     maxPriorityFeePerGas: 1000,
-  //     nonce: 0,
-  //     gasPrice: 1200000000,
-  //     gasLimit: 50000,
-  //     to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
-  //     value: 100,
-  //     data: null,
-  //     accessList: [
-  //       { 
-  //         address: '0xe242e54155b1abc71fc118065270cecaaf8b7768', 
-  //         storageKeys: [
-  //           '0x7154f8b310ad6ce97ce3b15e3419d9863865dfe2d8635802f7f4a52a206255a6'
-  //         ]
-  //       },
-  //       { 
-  //         address: '0xe0f8ff08ef0242c461da688b8b85e438db724860', 
-  //         storageKeys: []
-  //       }
-  //     ]
-  //   };
-  //   await testTxPass(buildTxReq(txData))
-  // })
+  it('Should test eip1559 with an access list (should pre-hash)', async () => {
+    const txData = {
+      chainId: 1,
+      type: 2,
+      maxFeePerGas: 1200000000,
+      maxPriorityFeePerGas: 1000,
+      nonce: 0,
+      gasPrice: 1200000000,
+      gasLimit: 50000,
+      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
+      value: 100,
+      data: '0xdeadbeef',
+      accessList: [
+        { 
+          address: '0xe242e54155b1abc71fc118065270cecaaf8b7768', 
+          storageKeys: [
+            '0x7154f8b310ad6ce97ce3b15e3419d9863865dfe2d8635802f7f4a52a206255a6'
+          ]
+        },
+        { 
+          address: '0xe0f8ff08ef0242c461da688b8b85e438db724860', 
+          storageKeys: []
+        }
+      ]
+    };
+    await testTxPass(buildTxReq(txData))
+  })
 
+  it('Should test eip2930 with no access list', async () => {
+    const txData = {
+      chainId: 1,
+      type: 1,
+      nonce: 0,
+      gasPrice: 1200000000,
+      gasLimit: 50000,
+      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
+      value: 100,
+      data: '0xdeadbeef',
+    };
+    await testTxPass(buildTxReq(txData))
+  })
+
+  it('Should test eip2930 with an access list (should pre-hash)', async () => {
+    const txData = {
+      chainId: 1,
+      type: 1,
+      nonce: 0,
+      gasPrice: 1200000000,
+      gasLimit: 50000,
+      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
+      value: 100,
+      data: '0xdeadbeef',
+      accessList: [
+        { 
+          address: '0xe242e54155b1abc71fc118065270cecaaf8b7768', 
+          storageKeys: [
+            '0x7154f8b310ad6ce97ce3b15e3419d9863865dfe2d8635802f7f4a52a206255a6'
+          ]
+        },
+        { 
+          address: '0xe0f8ff08ef0242c461da688b8b85e438db724860', 
+          storageKeys: []
+        }
+      ]
+    };
+    await testTxPass(buildTxReq(txData))
+  })
 })
-*/
+/*
 if (!process.env.skip) {
   describe('Test ETH Tx Params', () => {
     beforeEach(() => {
       expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');
       setTimeout(() => {}, 5000);
     })
-/*
+
     it('Should test and validate signatures from shorter derivation paths', async () => {
       if (constants.getFwVersionConst(client.fwVersion).varAddrPathSzAllowed) {
         // m/44'/60'/0'/x
@@ -248,7 +288,7 @@ if (!process.env.skip) {
       await testTxPass(buildTxReq(txData, `0x${(137).toString(16)}`));
       await testTxPass(buildTxReq(txData, `0x${(56).toString(16)}`));
     })
-*/
+
     it('Should test range of chainId sizes and EIP155 tag', async () => {
       const txData = JSON.parse(JSON.stringify(defaultTxData));
       // Add some random data for good measure, since this will interact with the data buffer
@@ -256,7 +296,7 @@ if (!process.env.skip) {
 
       let chainId = 1;
       // This one can fit in the normal chainID u8
-/*
+
       chainId = getChainId(8, -2); // 254
       await testTxPass(buildTxReq(txData, chainId))
       // These will need to go in the `data` buffer field
@@ -319,20 +359,19 @@ if (!process.env.skip) {
       const metadataSz = fwConstants.totalExtraEthTxDataSz || 0;
       const maxDataSz = (fwConstants.ethMaxDataSz - metadataSz) + 
                         (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
-      // txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
-      // await testTxPass(buildTxReq(txData, chainId));
-      // txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
-      // await testTxFail(buildTxReq(txData, chainId));
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
+      await testTxPass(buildTxReq(txData, chainId));
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
+      await testTxFail(buildTxReq(txData, chainId));
       // Also test smaller sizes
       chainId = getChainId(16, -1);
       chainIdSz = 3;
-      // txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
-      // await testTxPass(buildTxReq(txData, chainId));
+      txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
+      await testTxPass(buildTxReq(txData, chainId));
       txData.data = `0x${crypto.randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
-      console.log('dataSz', maxDataSz - chainIdSz + 1)
       await testTxFail(buildTxReq(txData, chainId));
     })
-/*
+
     it('Should test range of `value`', async () => {
       const txData = JSON.parse(JSON.stringify(defaultTxData))
       txData.value = 1;
@@ -441,10 +480,10 @@ if (!process.env.skip) {
       // For non-EIP155 transactions, we expect `v` to be 27 or 28
       expect(res.sig.v.toString('hex')).to.oneOf([(27).toString(16), (28).toString(16)])
     });
-*/
+
   });
 }
-/*
+
 describe('Test random transaction data', function() {
   beforeEach(() => {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');


### PR DESCRIPTION
Adds support for new EIP1559 and EIP2930 transaction types.

*Note: `accessList` param is not supported in firmware, so if a non-empty `accessList` is passed to the SDK it will pre-hash the payload. This means the user is still able to sign the transaction, but it cannot be displayed on the secure screen.*