### PR TITLE
Fixes issue related to writing large chainIds + unrelated cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -314,10 +314,11 @@ if (!process.env.skip) {
         await testTxFail(buildTxReq(txData, 1, path.slice(0, 1)));            
       }
     })
-    it('Should test that chainId=137 shows "MATIC" and chainId=56 shows "BNB" units', async () => {
+    it('Should test named units', async () => {
       const txData = JSON.parse(JSON.stringify(defaultTxData));
       await testTxPass(buildTxReq(txData, `0x${(137).toString(16)}`));
       await testTxPass(buildTxReq(txData, `0x${(56).toString(16)}`));
+      await testTxPass(buildTxReq(txData, `0x${(43114).toString(16)}`));      
     })
 
     it('Should test range of chainId sizes and EIP155 tag', async () => {


### PR DESCRIPTION
We had an edge case where large chainIds were not writing to transaction
payloads when the `data` field was null. This is now corrected.
Also adds a test for a readable AVAX asset name on the Lattice and
adds a sanity check for EIP1559 transactions to prevent the tip
from exceeding maxFee.