### PR TITLE
Fixes bug in parsing ABI inputs (in static decoding script)

### DIFF
--- a/src/ethereumAbi.js
+++ b/src/ethereumAbi.js
@@ -144,7 +144,7 @@ function parseEtherscanAbiInputs(inputs, data=[], isNestedTuple=false) {
           d.isArray = true;
         } else {
           // Parse the array size if applicable
-          const number = parseInt(typeName.slice(openBracketIdx, closeBracketIdx))
+          const number = parseInt(typeName.slice(openBracketIdx + 1, closeBracketIdx))
           if (isNaN(number)) {
             return d;
           }


### PR DESCRIPTION
It seems functions with fixed array size types are uncommon because we just
now ran into this edge case where the script was incorrectly parsing these
types and leading to invalid function signatures.
Just an off-by-one error. Oops.