### PR TITLE
Fixes off-by-one error in ABI decoding util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/src/ethereumAbi.js
+++ b/src/ethereumAbi.js
@@ -144,7 +144,7 @@ function parseEtherscanAbiInputs(inputs, data=[], isNestedTuple=false) {
           d.isArray = true;
         } else {
           // Parse the array size if applicable
-          const number = parseInt(typeName.slice(openBracketIdx, closeBracketIdx))
+          const number = parseInt(typeName.slice(openBracketIdx + 1, closeBracketIdx))
           if (isNaN(number)) {
             return d;
           }


### PR DESCRIPTION
This is a hotfix release and does not affect any Lattice-based functionality.