### PR TITLE
Accounts for change in max `personal_sign` payload size from v0.11.2

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -302,7 +302,16 @@ function getFwVersionConst(v) {
     // EXTRA FIELDS ADDED IN LATER VERSIONS
     //-------------------------------------
 
-    // V0.10.12 allows new ETH transaction types
+    // V0.11.2 changed how messages are displayed. For personal_sign messages
+    // we now write the header (`Signer: <path>`) into the main body of the screen.
+    // This means personal sign message max size is slightly smaller than for
+    // EIP712 messages because in the latter case there is no header
+    // Note that `<path>` has max size of 62 bytes (`m/X/X/...`)
+    if (!legacy && gte(v, [0, 11, 2])) {
+        c.personalSignHeaderSz = 72;
+    }
+
+    // V0.11.0 allows new ETH transaction types
     if (!legacy && gte(v, [0, 11, 0])) {
         c.allowedEthTxTypesVersion = 1;
         c.allowedEthTxTypes = [

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -594,7 +594,11 @@ function buildPersonalSignRequest(req, input) {
     displayHex = false === isASCIIStr(input.payload.toString())
   }
   const fwConst = input.fwConstants;
-  const maxSzAllowed = MAX_BASE_MSG_SZ + (fwConst.extraDataMaxFrames * fwConst.extraDataFrameSz);
+  let maxSzAllowed = MAX_BASE_MSG_SZ + (fwConst.extraDataMaxFrames * fwConst.extraDataFrameSz);
+  if (fwConst.personalSignHeaderSz) {
+    // Account for the personal_sign header string
+    maxSzAllowed -= fwConst.personalSignHeaderSz;
+  }
   if (fwConst.ethMsgPreHashAllowed && payload.length > maxSzAllowed) {
     // If this message will not fit and pre-hashing is allowed, do that
     req.payload.writeUInt8(displayHex, off); off += 1;

--- a/test/testEthMsg.js
+++ b/test/testEthMsg.js
@@ -112,7 +112,7 @@ describe('Setup client', () => {
     ETH_GAS_PRICE_MAX = fwConstants.ethMaxGasPrice;
   });
 })
-/*
+
 describe('Test ETH personalSign', function() {
   beforeEach(() => {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');
@@ -139,15 +139,29 @@ describe('Test ETH personalSign', function() {
     await testMsg(buildMsgReq(crypto.randomBytes(4000), 'signPersonal'), true);
   })
 
-  it('Msg: sign_personal boundary conditions', async () => {
+  it('Msg: sign_personal boundary conditions and auto-rejected requests', async () => {
     const protocol = 'signPersonal';
     const fwConstants = constants.getFwVersionConst(client.fwVersion);
     const metadataSz = fwConstants.totalExtraEthTxDataSz || 0;
-    const maxMsgSz =  (fwConstants.ethMaxMsgSz - metadataSz) + 
+    // `personal_sign` requests have a max size smaller than other requests because a header
+    // is displayed in the text region of the screen. The size of this is captured
+    // by `fwConstants.personalSignHeaderSz`.
+    const maxMsgSz =  (fwConstants.ethMaxMsgSz - metadataSz - fwConstants.personalSignHeaderSz) + 
                       (fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz);
     const maxValid = `0x${crypto.randomBytes(maxMsgSz).toString('hex')}`;
+    const minInvalid = `0x${crypto.randomBytes(maxMsgSz+1).toString('hex')}`;
     const zeroInvalid = '0x';
-    await testMsg(buildMsgReq(maxValid, protocol), true);
+    // The largest non-hardened index which will take the most chars to print
+    const x = HARDENED_OFFSET - 1;
+    // Okay sooo this is a bit awkward. We have to use a known coin_type here (e.g. ETH)
+    // or else firmware will return an error, but the maxSz is based on the max length
+    // of a path, which is larger than we can actually print.
+    // I guess all this tests is that the first one is shown in plaintext while the second
+    // one (which is too large) gets prehashed.
+    const largeSignPath = [x, HARDENED_OFFSET+60, x, x, x]
+    await testMsg(buildMsgReq(maxValid, protocol, largeSignPath), true);
+    await testMsg(buildMsgReq(minInvalid, protocol, largeSignPath), true);
+    // Using a zero length payload should auto-reject
     await testMsg(buildMsgReq(zeroInvalid, protocol), false);
   })
 
@@ -163,7 +177,7 @@ describe('Test ETH personalSign', function() {
   })
 
 })
-*/
+
 describe('Test ETH EIP712', function() {
   beforeEach(() => {
     expect(foundError).to.equal(false, 'Error found in prior test. Aborting.');


### PR DESCRIPTION
In v0.11.2 firmware we changed how message requests are displayed.
We now have a single, large buffer which contains the entire message
being used.
In the case of `personal_sign`, firmware now writes a string which
can be up to 71 characters (72 bytes) as the prefix, so our max
payload size needs to shrink by that amount. EIP712 and ETH tx
requests are unaffected.
Also updates the relevant tests.