### PR TITLE
Release 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2959,6 +2959,23 @@
         "inherits": "^2.0.1"
       }
     },
+    "rlp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        }
+      }
+    },
     "rlp-browser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rlp-browser/-/rlp-browser-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mocha": "^5.2.0",
     "random-words": "^1.1.1",
     "readline-sync": "^1.4.9",
+    "rlp": "^2.2.7",
     "seedrandom": "^3.0.5"
   },
   "files": [

--- a/src/ethereum.js
+++ b/src/ethereum.js
@@ -232,15 +232,15 @@ exports.buildEthereumTxRequest = function(data) {
       if (PREHASH_FROM_ACCESS_LIST) {
         PREHASH_UNSUPPORTED = true;
       }
-      txReqPayload.writeUint8(PREHASH_UNSUPPORTED === true, off); off += 1;  
+      txReqPayload.writeUInt8(PREHASH_UNSUPPORTED === true, off); off += 1;  
       // EIP1559 & EIP2930 struct version
       if (isEip1559) {
-        txReqPayload.writeUint8(2, off); off += 1; // Eip1559 type enum value
+        txReqPayload.writeUInt8(2, off); off += 1; // Eip1559 type enum value
         if (maxPriorityFeePerGasBytes.length > 8)
           throw new Error('maxPriorityFeePerGasBytes too large');
         maxPriorityFeePerGasBytes.copy(txReqPayload, off + (8 - maxPriorityFeePerGasBytes.length)); off += 8;
       } else if (isEip2930) {
-        txReqPayload.writeUint8(1, off); off += 1; // Eip2930 type enum value
+        txReqPayload.writeUInt8(1, off); off += 1; // Eip2930 type enum value
         off += extraEthTxDataSz - 2; // Skip EIP1559 params
       } else {
         off += extraEthTxDataSz - 1; // Skip EIP1559 and EIP2930 params

--- a/test/testSigs.js
+++ b/test/testSigs.js
@@ -150,6 +150,7 @@ describe('Test non-exportable seed on SafeCard (if available)', () => {
   // the test route is commented out.
   // TODO: Remove this comment when bug is fixed in firmware.
   it('Should ask if the user wants to test a card with a non-exportable seed', async () => {
+    // NOTE: non-exportable seeds were deprecated from the normal setup pathway in firmware v0.12.0
     const result = question(
       '\nIf you have a SafeCard with a NON-EXPORTABLE seed loaded, please insert and unlock it now.' +
       '\nDo you have a non-exportable SafeCard seed loaded and wish to continue? (Y/N) '
@@ -229,15 +230,6 @@ describe('Test non-exportable seed on SafeCard (if available)', () => {
     expect(sig2).to.not.equal(jsSig, 'Addr8 sig was not random');
     expect(sig2).to.not.equal(sig, 'Addr8 sig was not random');
   })
-
-  it('Should ask the user to insert the original card.', async () => {
-    if (skipNonExportableSeed)
-      return;
-    question(
-      '\nPlease remove your SafeCard (with the non-exportable seed) and re-insert + unlock' +
-      '\nyour original SafeCard. Press enter once the original card is inserted and unlocked.'
-    );
-  });
 })
 
 describe('Setup Test', () => {
@@ -250,10 +242,19 @@ describe('Setup Test', () => {
     // This should only be selected if the user has previously chosen not
     // to re-load the original seed at the end of this test script.
     const result = question(
-      '\nDo you have the test seed loaded already? (Y/N) '
+      'Please insert and unlock a normal SafeCard (with an exportable seed).' +
+      '\nDo you have the test seed loaded on this card already? (Y/N) '
     );
     if (result.toLowerCase() !== 'n') {
       skipSeedLoading = true;
+    } else {
+      // TODO: Remove this once firmware is fixed
+      console.log('WARNING: if you ran the non-exportable seed tests and also are trying ' +
+                  'to load a seed here, your tests will fail. This has to do with some ' +
+                  'edge case in the firmware test runner and EMV applet. We are looking into ' +
+                  'it but for now please do not use this combination. This issue only ' +
+                  'affects the test runner which is why it is not higher priority');
+
     }
   })
 

--- a/test/testUtil/helpers.js
+++ b/test/testUtil/helpers.js
@@ -14,6 +14,7 @@ const ec = new EC('secp256k1');
 // NOTE: We use the HARDEN(49) purpose for p2sh(p2wpkh) address derivations.
 //       For p2pkh-derived addresses, we use the legacy 44' purpose
 //       For p2wpkh-derived addresse (not yet supported) we will use 84'
+exports.HARDENED_OFFSET = HARDENED_OFFSET;
 exports.BTC_PURPOSE_P2SH_P2WPKH = HARDENED_OFFSET+49;
 exports.BTC_LEGACY_PURPOSE = HARDENED_OFFSET+44;
 exports.BTC_COIN = HARDENED_OFFSET;

--- a/test/testWalletJobs.js
+++ b/test/testWalletJobs.js
@@ -255,7 +255,7 @@ describe('getAddresses', () => {
     }
   })
 
-  it('Should fetch with a shorter derivation path', async () => {
+  it('Should validate address with pathDepth=4', async () => {
     const req = { 
       currency: 'ETH', 
       startPath: [7842, helpers.ETH_COIN, 2532356, 7], 
@@ -280,6 +280,29 @@ describe('getAddresses', () => {
     helpers.validateETHAddresses(resp, jobData, activeWalletSeed);
   })
 
+  it('Should validate address with pathDepth=3', async () => {
+    const req = { 
+      currency: 'ETH', 
+      startPath: [7842, helpers.ETH_COIN, 2532356], 
+      n: 3,
+      skipCache: true,
+    }
+    const addrs = await helpers.execute(client, 'getAddresses', req, 2000);
+    const resp = {
+      count: addrs.length,
+      addresses: addrs,
+    }
+    const jobData = {
+      parent: {
+        pathDepth: 2,
+        purpose: req.startPath[0],
+        coin: req.startPath[1],
+      },
+      count: req.n,
+      first: req.startPath[2],
+    }
+    helpers.validateETHAddresses(resp, jobData, activeWalletSeed);
+  })
 })
 
 describe('signTx', () => {


### PR DESCRIPTION
**Changelog:**

* (#189) - Reorders `test-sigs` test
* (#191) - Capitalizes `UInt8Array` instances which were failing in browser environments
* (#192) - Adds tests for signing out of private keys with leading zeros
* (#193) - Modifies `test-sigs` test
* (#194) - Fixes issues in and adds determinism to `test-btc`
* (#195) - Adds tests for signing out of public keys with leading zeros
* (#190) - Adds test to validate `pathDepth=3` 