### PR TITLE
Handle removal of caching

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,6 @@ client.addresses(req, (err, res) => {
 |:-----------|:----------|:-----------------|:----------------|:----------------------|
 | `startPath` | Array    | none             | n/a             | First address path in BIP44 tree to return. You must provide 5 indices to form the path. |
 | `n`        | number    | 1                | n/a             | Number of subsequent addresses after `start` to derive. These will increment over the final index in the path |
-| `skipCache` | bool     | true            | n/a             | If set to true, skip the restriction that only cached addresses may be requested. This allows the user to request any address for a supported currency (BTC and ETH). Ignored for Lattice firmware versions <0.10.0 |
 
 **Response:**
 
@@ -131,16 +130,6 @@ res = [
     '3PNwCSHKNfCjzvcU8XE9N8wp8DRxrUzsyL'
 ]
 ```
-
-## The Address Cache
-
-If `skipCache=false`, the requester may only fetch addresses that have been saved to the Lattice's cache. This is used mainly for BTC to keep track
-of which addresses have been generated in an effort to sync an HD wallet. **Since the gap limit of ETH is 0, caching isn't relevant for it, so you should generally use `skipCache=true` when requesting ETH addresses.**
-
-The following restrictions apply when using `skipCache=false`:
-
-* `ETH`: The Lattice only returns the 0-th index address (`m/44'/60'/0'/0/0`) of the current wallet (either on-board Lattice or external SafeCard). This means `n` must be equal to `1` and the only acceptable path is that of the 0-th index address.
-* `BTC`: Currently we only support `p2sh-p2wpkh` BTC addresses which use [BIP49](https://en.bitcoin.it/wiki/BIP_0049): `m/49'/0'/0'/0/x`. If testnet is enabled (`testnet3`), we also allow `m/49'/1'/0'/0/x`. Here, `x` may be any address that has been "cached" by the Lattice. We cache addresses relative to the requested address based on the [gap limit](https://blog.blockonomics.co/bitcoin-what-is-this-gap-limit-4f098e52d7e1?gi=616654046ec4). For the regular wallet, the gap limit is 20. In addition to these addresses, the user may request change addresses (`m/49'/0'/0/1/x` and `m/49'/1'/0'/1/x`). The gap limit for change addresses is 1. Because the Lattice itself is stateless, it creates new addresses whenever previous addresses are requested. For example, if regular addresses 0-19 have been cached (i.e. on an initial cache) and the user requests addresses 9-19, the wallet would then cache 20-29 and the user could then request any of those addresses (which would, in turn, lead to more becoming available). The same logic applies for change addresses, but only the subsequent one would get cached. Note that if you request addresses outside of the gap limit, you will get an error and no new addresses will be cached.
 
 # Requesting Signatures
 

--- a/src/client.js
+++ b/src/client.js
@@ -170,7 +170,7 @@ class Client {
   getAddresses(opts, cb) {
     const SKIP_CACHE_FLAG = 1;
     const MAX_ADDR = 10;
-    const { startPath, n, skipCache=true } = opts;
+    const { startPath, n } = opts;
     if (startPath === undefined || n === undefined)
       return cb('Please provide `startPath` and `n` options');
     if (startPath.length < 2 || startPath.length > 5)
@@ -210,7 +210,9 @@ class Client {
     // in the wallet.
     let val;
     if (true === fwConstants.addrFlagsAllowed) {
-      const flag = skipCache === true ? bitwise.nibble.read(SKIP_CACHE_FLAG) : bitwise.nibble.read(0);
+      // Address caching was removed in 0.13.0 so this flag is now deprecated.
+      // All requests against older devices also use the skipFlag=true now.
+      const flag = bitwise.nibble.read(SKIP_CACHE_FLAG);
       const count = bitwise.nibble.read(n);
       val = bitwise.byte.write(flag.concat(count));
     } else {

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -65,7 +65,6 @@ describe('Connect and Pair', () => {
         currency: 'BTC', 
         startPath: [helpers.BTC_PURPOSE_P2SH_P2WPKH, helpers.BTC_COIN, HARDENED_OFFSET, 0, 0], 
         n: 5,
-        skipCache: false,
       }
       // Bitcoin addresses
       // NOTE: The format of address will be based on the user's Lattice settings
@@ -88,20 +87,10 @@ describe('Connect and Pair', () => {
           currency: 'ETH', 
           startPath: [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0], 
           n: 1,
-          skipCache: true,
         }
         addrs = await helpers.execute(client, 'getAddresses', flexData, 2000);
         expect(addrs.length).to.equal(1);
         expect(addrs[0].slice(0, 2)).to.equal('0x')
-        // Should fail to fetch this if skipCache = false because this is not
-        // a supported asset's parent path
-        flexData.skipCache = false
-        try {
-          addrs = await helpers.execute(client, 'getAddresses', flexData, 2000);
-          expect(addrs).to.equal(null)
-        } catch (err) {
-          expect(err).to.not.equal(null)
-        }
       }
 
       // Bitcoin testnet
@@ -115,33 +104,17 @@ describe('Connect and Pair', () => {
 
       // Bech32
       addrData.startPath[0] = helpers.BTC_PURPOSE_P2WPKH;
-      addrData.skipCache = true;
       addrData.n = 1;
       addrs = await helpers.execute(client, 'getAddresses', addrData, 2000);
       expect(addrs.length).to.equal(1);
       expect(addrs[0].slice(0, 3)).to.be.oneOf(['bc1']);
       addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
-      addrData.skipCache = false;
       addrData.n = 5;
 
-      // Keys outside the cache with skipCache = true
       addrData.startPath[4] = 1000000;
       addrData.n = 3;
-      addrData.skipCache = true;
       addrs = await helpers.execute(client, 'getAddresses', addrData, 2000);
       expect(addrs.length).to.equal(addrData.n);
-      
-      // --- EXPECTED FAILURES ---
-      // Keys outside the cache with skipCache = false
-      addrData.startPath[4] = 1000000;
-      addrData.n = 3;
-      addrData.skipCache = false;
-      try {
-        addrs = await helpers.execute(client, 'getAddresses', addrData, 2000);
-        expect(addrs).to.equal(null);
-      } catch (err) {
-        expect(err).to.not.equal(null);
-      }
       addrData.startPath[4] = 0;
       addrData.n = 1;
 
@@ -172,6 +145,7 @@ describe('Connect and Pair', () => {
       } catch (err) {
         expect(err).to.not.equal(null);
       }
+
     }
   });
 

--- a/test/testEth.js
+++ b/test/testEth.js
@@ -22,7 +22,6 @@ const constants = require('./../src/constants')
 const expect = require('chai').expect;
 const helpers = require('./testUtil/helpers');
 const seedrandom = require('seedrandom');
-const keccak256 = require('js-sha3').keccak256;
 const prng = new seedrandom(process.env.SEED || 'myrandomseed');
 const HARDENED_OFFSET = constants.HARDENED_OFFSET;
 let client = null;
@@ -32,7 +31,6 @@ const randomTxDataLabels = [];
 let ETH_GAS_PRICE_MAX;                  // value depends on firmware version
 const ETH_GAS_LIMIT_MIN = 22000;        // Ether transfer (smallest op) is 22k gas
 const ETH_GAS_LIMIT_MAX = 12500000;     // 10M is bigger than the block size
-const MSG_PAYLOAD_METADATA_SZ = 28;     // Metadata that must go in ETH_MSG requests
 const defaultTxData = {
   nonce: 0,
   gasPrice: 1200000000,

--- a/test/testSigs.js
+++ b/test/testSigs.js
@@ -328,7 +328,6 @@ describe('Setup Test', () => {
       currency: 'ETH',
       startPath: path0,
       n: 1,
-      skipCache: true,
     }
     const latAddr0 = await helpers.execute(client, 'getAddresses', req, 2000);
     expect(latAddr0[0].toLowerCase()).to.equal(addr0.toLowerCase(), 'Incorrect address 0 fetched.')

--- a/test/testUtil/helpers.js
+++ b/test/testUtil/helpers.js
@@ -296,11 +296,29 @@ exports.gpErrors = {
   GP_EALREADY: (0xffffffff+1) - 114, // (4294967153)
   GP_ENODEV: (0xffffffff+1) - 19, // (4294967058)
   GP_EAGAIN: (0xffffffff+1) - 11, // (4294967050)
+  GP_FAILURE: (0xffffffff+1) - 128,
 }
 
 //---------------------------------------------------
 // General helpers
 //---------------------------------------------------
+exports.getCodeMsg = function(code, expected) {
+  if (code !== expected) {
+    let codeTxt = code, expectedTxt = expected;
+    Object.keys(exports.gpErrors).forEach((key) => {
+      if (code === exports.gpErrors[key]) {
+        codeTxt = key;
+      }
+      if (expected === exports.gpErrors[key]) {
+        expectedTxt = key;
+      }
+    })
+    return `Incorrect response code. Got ${codeTxt}. Expected ${expectedTxt}`
+  }
+  return '';
+}
+
+
 exports.parseWalletJobResp = function(res, v) {
   const jobRes = {
     resultStatus: null,
@@ -418,9 +436,8 @@ exports.serializeGetAddressesJobData = function(data) {
   req.writeUInt32LE(data.parent.addr, off); off+=4;
   req.writeUInt32LE(data.first, off); off+=4;
   req.writeUInt32LE(data.count, off); off+=4;
-  if (data.flag) {
-    req.writeUInt8(data.flag, off);
-  }
+  // Deprecated skipCache flag. It isn't used by firmware anymore.
+  req.writeUInt8(1, off);
   return req;
 }
 


### PR DESCRIPTION
Latice firmware v0.13.0 removes caching addresses and instead builds the addresses as part of the request. Previously we cached the first 20 BTC addresses, which took 1-2 minutes every time a new wallet was setup. We also haven't requested cached addresses in the wild for a long time (only a very old version of the Web Wallet, now rebranded to Lattice Manager, used cached addresses). It is much easier (and a better UX) to simply manage the addresses on the client side.

This PR removes the `skipCache` flag and instead marks it as `true` in all cases now. This flag is deprecated in v0.13.0 but we should keep it in the SDK for backwards compatibility.

It also removes all tests related to caching.