### PR TITLE
Replaces ethers-eip712 with eth-eip712-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.5.0.tgz",
       "integrity": "sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==",
+      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -50,6 +51,7 @@
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
           "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.5.0",
             "@ethersproject/bytes": "^5.5.0",
@@ -64,6 +66,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
           "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+          "dev": true,
           "requires": {
             "@ethersproject/abstract-provider": "^5.5.0",
             "@ethersproject/bignumber": "^5.5.0",
@@ -76,6 +79,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
           "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.5.0",
             "@ethersproject/bytes": "^5.5.0",
@@ -88,6 +92,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
           "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.5.0"
           }
@@ -96,6 +101,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
           "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.5.0"
           }
@@ -104,6 +110,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
           "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+          "dev": true,
           "requires": {
             "@ethersproject/bignumber": "^5.5.0"
           }
@@ -112,6 +119,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
           "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+          "dev": true,
           "requires": {
             "@ethersproject/abstract-signer": "^5.5.0",
             "@ethersproject/address": "^5.5.0",
@@ -127,6 +135,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
           "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.5.0",
             "js-sha3": "0.8.0"
@@ -135,12 +144,14 @@
         "@ethersproject/logger": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+          "dev": true
         },
         "@ethersproject/networks": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
           "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
+          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.5.0"
           }
@@ -149,6 +160,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
           "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.5.0"
           }
@@ -157,6 +169,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
           "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.5.0",
             "@ethersproject/logger": "^5.5.0"
@@ -166,6 +179,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
           "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.5.0",
             "@ethersproject/logger": "^5.5.0",
@@ -179,6 +193,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
           "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+          "dev": true,
           "requires": {
             "@ethersproject/bytes": "^5.5.0",
             "@ethersproject/constants": "^5.5.0",
@@ -189,6 +204,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
           "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+          "dev": true,
           "requires": {
             "@ethersproject/address": "^5.5.0",
             "@ethersproject/bignumber": "^5.5.0",
@@ -205,6 +221,7 @@
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
           "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+          "dev": true,
           "requires": {
             "@ethersproject/base64": "^5.5.0",
             "@ethersproject/bytes": "^5.5.0",
@@ -215,36 +232,11 @@
         }
       }
     },
-    "@ethersproject/abstract-provider": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
-      "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/networks": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/web": "^5.5.0"
-      }
-    },
-    "@ethersproject/abstract-signer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
-      "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0"
-      }
-    },
     "@ethersproject/address": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
       "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.5.0",
         "@ethersproject/bytes": "^5.5.0",
@@ -253,27 +245,11 @@
         "@ethersproject/rlp": "^5.5.0"
       }
     },
-    "@ethersproject/base64": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-      "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0"
-      }
-    },
-    "@ethersproject/basex": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.5.0.tgz",
-      "integrity": "sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0"
-      }
-    },
     "@ethersproject/bignumber": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
       "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.5.0",
         "@ethersproject/logger": "^5.5.0",
@@ -284,6 +260,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
           "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+          "dev": true,
           "requires": {
             "@ethersproject/logger": "^5.5.0"
           }
@@ -291,7 +268,8 @@
         "@ethersproject/logger": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+          "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+          "dev": true
         }
       }
     },
@@ -299,6 +277,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
       "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.5.0"
       }
@@ -307,92 +286,16 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
       "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.5.0"
-      }
-    },
-    "@ethersproject/contracts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.5.0.tgz",
-      "integrity": "sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==",
-      "requires": {
-        "@ethersproject/abi": "^5.5.0",
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0"
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
-      "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
-      }
-    },
-    "@ethersproject/hdnode": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.5.0.tgz",
-      "integrity": "sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/basex": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/pbkdf2": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/wordlists": "^5.5.0"
-      }
-    },
-    "@ethersproject/json-wallets": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz",
-      "integrity": "sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hdnode": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/pbkdf2": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      },
-      "dependencies": {
-        "aes-js": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-        }
       }
     },
     "@ethersproject/keccak256": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
       "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.5.0",
         "js-sha3": "0.8.0"
@@ -401,72 +304,15 @@
     "@ethersproject/logger": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
-    },
-    "@ethersproject/networks": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.1.tgz",
-      "integrity": "sha512-tYRDM4zZtSUcKnD4UMuAlj7SeXH/k5WC4SP2u1Pn57++JdXHkRu2zwNkgNogZoxHzhm9Q6qqurDBVptHOsW49Q==",
-      "requires": {
-        "@ethersproject/logger": "^5.5.0"
-      }
-    },
-    "@ethersproject/pbkdf2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz",
-      "integrity": "sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0"
-      }
+      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+      "dev": true
     },
     "@ethersproject/properties": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
       "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+      "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.5.0"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.1.tgz",
-      "integrity": "sha512-2zdD5sltACDWhjUE12Kucg2PcgM6V2q9JMyVvObtVGnzJu+QSmibbP+BHQyLWZUBfLApx2942+7DC5D+n4wBQQ==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/basex": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/networks": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/web": "^5.5.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-        }
-      }
-    },
-    "@ethersproject/random": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
-      "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0",
         "@ethersproject/logger": "^5.5.0"
       }
     },
@@ -474,25 +320,17 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
       "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.5.0",
         "@ethersproject/logger": "^5.5.0"
-      }
-    },
-    "@ethersproject/sha2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
       "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.5.0",
         "@ethersproject/logger": "^5.5.0",
@@ -502,33 +340,11 @@
         "hash.js": "1.1.7"
       }
     },
-    "@ethersproject/solidity": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.5.0.tgz",
-      "integrity": "sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
-      }
-    },
-    "@ethersproject/strings": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
-      "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
-      }
-    },
     "@ethersproject/transactions": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
       "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
@@ -539,62 +355,6 @@
         "@ethersproject/properties": "^5.5.0",
         "@ethersproject/rlp": "^5.5.0",
         "@ethersproject/signing-key": "^5.5.0"
-      }
-    },
-    "@ethersproject/units": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.5.0.tgz",
-      "integrity": "sha512-7+DpjiZk4v6wrikj+TCyWWa9dXLNU73tSTa7n0TSJDxkYbV3Yf1eRh9ToMLlZtuctNYu9RDNNy2USq3AdqSbag==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
-      }
-    },
-    "@ethersproject/wallet": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.5.0.tgz",
-      "integrity": "sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/hdnode": "^5.5.0",
-        "@ethersproject/json-wallets": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/wordlists": "^5.5.0"
-      }
-    },
-    "@ethersproject/web": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
-      "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
-      "requires": {
-        "@ethersproject/base64": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
-      }
-    },
-    "@ethersproject/wordlists": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.5.0.tgz",
-      "integrity": "sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==",
-      "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
       }
     },
     "@types/bn.js": {
@@ -1677,6 +1437,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eth-eip712-util": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/eth-eip712-util/-/eth-eip712-util-2.3.1.tgz",
+      "integrity": "sha512-4Q7udznDnb0g+Dd5AWz4bRztCTs68MYm5NlxgA4PEhSL1NpJPDvGLcop0BHdDTeKCeJGoIAzJWa7wausJbTb3w=="
+    },
     "ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
@@ -1738,48 +1503,6 @@
           }
         }
       }
-    },
-    "ethers": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.2.tgz",
-      "integrity": "sha512-EF5W+6Wwcu6BqVwpgmyR5U2+L4c1FQzlM/02dkZOugN3KF0cG9bzHZP+TDJglmPm2/IzCEJDT7KBxzayk7SAHw==",
-      "requires": {
-        "@ethersproject/abi": "5.5.0",
-        "@ethersproject/abstract-provider": "5.5.1",
-        "@ethersproject/abstract-signer": "5.5.0",
-        "@ethersproject/address": "5.5.0",
-        "@ethersproject/base64": "5.5.0",
-        "@ethersproject/basex": "5.5.0",
-        "@ethersproject/bignumber": "5.5.0",
-        "@ethersproject/bytes": "5.5.0",
-        "@ethersproject/constants": "5.5.0",
-        "@ethersproject/contracts": "5.5.0",
-        "@ethersproject/hash": "5.5.0",
-        "@ethersproject/hdnode": "5.5.0",
-        "@ethersproject/json-wallets": "5.5.0",
-        "@ethersproject/keccak256": "5.5.0",
-        "@ethersproject/logger": "5.5.0",
-        "@ethersproject/networks": "5.5.1",
-        "@ethersproject/pbkdf2": "5.5.0",
-        "@ethersproject/properties": "5.5.0",
-        "@ethersproject/providers": "5.5.1",
-        "@ethersproject/random": "5.5.0",
-        "@ethersproject/rlp": "5.5.0",
-        "@ethersproject/sha2": "5.5.0",
-        "@ethersproject/signing-key": "5.5.0",
-        "@ethersproject/solidity": "5.5.0",
-        "@ethersproject/strings": "5.5.0",
-        "@ethersproject/transactions": "5.5.0",
-        "@ethersproject/units": "5.5.0",
-        "@ethersproject/wallet": "5.5.0",
-        "@ethersproject/web": "5.5.1",
-        "@ethersproject/wordlists": "5.5.0"
-      }
-    },
-    "ethers-eip712": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethers-eip712/-/ethers-eip712-0.2.0.tgz",
-      "integrity": "sha512-fgS196gCIXeiLwhsWycJJuxI9nL/AoUPGSQ+yvd+8wdWR+43G+J1n69LmWVWvAON0M6qNaf2BF4/M159U8fujQ=="
     },
     "ethjs-util": {
       "version": "0.1.6",
@@ -3191,7 +2914,8 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "secp256k1": {
       "version": "4.0.2",
@@ -3676,11 +3400,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "y18n": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "url": "https://github.com/GridPlus/gridplus-sdk.git"
   },
   "dependencies": {
-    "@ethersproject/bignumber": "^5.5.0",
     "aes-js": "^3.1.1",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.0.1",
@@ -34,8 +33,7 @@
     "buffer": "^5.6.0",
     "crc-32": "^1.2.0",
     "elliptic": "6.5.4",
-    "ethers": "^5.5.2",
-    "ethers-eip712": "^0.2.0",
+    "eth-eip712-util": "^2.3.1",
     "js-sha3": "^0.8.0",
     "rlp-browser": "^1.0.1",
     "secp256k1": "4.0.2",

--- a/test/testEthMsg.js
+++ b/test/testEthMsg.js
@@ -218,6 +218,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -257,6 +258,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -308,6 +310,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -325,6 +328,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -368,6 +372,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -421,6 +426,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -484,6 +490,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -557,6 +564,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -630,6 +638,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -691,6 +700,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -764,6 +774,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -822,6 +833,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -910,6 +922,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -995,11 +1008,152 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
+      expect(err).to.equal(null)
+    }
+  })
+
+  it('Should test a payload with a nested type in multiple nesting levels', async () => {   
+    const msg = {
+      'types': {
+        'EIP712Domain': [
+          {
+            'name': 'name',
+            'type': 'string'
+          },
+        ],
+        'PrimaryType': [
+          {
+            'name': 'one',
+            'type': 'Type1'
+          },
+          {
+            'name': 'zero',
+            'type': 'Type0'
+          },
+        ],
+        'Type1': [
+          {
+            'name': '1s',
+            'type': 'string'
+          },
+        ],
+        'Type0': [
+          {
+            'name': 'one',
+            'type': 'Type1'
+          }
+        ]
+      },
+      'primaryType': 'PrimaryType',
+      'domain': {
+        'name': 'Domain',
+      },
+      'message': {
+        'one': {
+          '1s': 'nestedOne',
+        },
+        'zero': {
+          'one': {
+            '1s': 'nestedTwo',
+          }
+        },
+      }
+    }
+
+    const req = {
+      currency: 'ETH_MSG',
+      data: {
+        signerPath: [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0],
+        protocol: 'eip712',
+        payload: msg,
+      }
+    }
+    try {
+      await helpers.execute(client, 'sign', req);
+    } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
 
   it('Should test a payload that requires use of extraData frames', async () => {
+    const msg = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' }
+        ],
+        Wallet: [
+          { name: 'address', type: 'address' },
+          { name: 'balance', type: 'Balance' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallet', type: 'Wallet' }
+        ],
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person' },
+          { name: 'contents', type: 'string' }
+        ],
+        Balance: [
+          { name: 'value', type: 'uint256' },
+          { name: 'currency', type: 'string' }
+        ]
+      },
+      primaryType: 'Mail',
+      domain: {
+        name: 'Ether Mail',
+        version: '1',
+        chainId: 12,
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
+      },
+      message: {
+        from: {
+          name: 'Cow',
+          wallet: {
+            address: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            balance: {
+              value: '0x12345678',
+              currency: 'ETH',
+            }
+          },
+        },
+        to: {
+          name: 'Bob',
+          wallet: {
+            address: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+            balance: {
+              value: '0xabcdef12',
+              currency: 'UNI',
+            },
+          },
+        },
+        contents: 'stupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimesstupidlylongstringthatshouldstretchintomultiplepageswhencopiedmanytimes'
+      }
+    };
+    const req = {
+      currency: 'ETH_MSG',
+      data: {
+        signerPath: [helpers.BTC_LEGACY_PURPOSE, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0],
+        protocol: 'eip712',
+        payload: msg,
+      }
+    }
+    try {
+      await helpers.execute(client, 'sign', req);
+    } catch (err) {
+      foundError = true;
+      expect(err).to.equal(null)
+    }
+  });
+
+  it('Should test random edge case #1', async () => {
+    // This was a randomly generated payload which caused an edge case.
+    // It has been slimmed down but definition structure is preserved.
     const msg = {
       'types': {
         'EIP712Domain': [
@@ -1020,95 +1174,61 @@ describe('Test ETH EIP712', function() {
             'type': 'address'
           }
         ],
-        'Primary_Promote_room_donate_': [
+        'Primary_Click': [
           {
-            'name': 'assist_dumb_bubble_g',
-            'type': 'Open_either_fetch_gr'
+            'name': 'utility',
+            'type': 'Expose'
           },
           {
-            'name': 'jungle_symptom_meat_',
-            'type': 'Unfair_device_vocal_'
+            'name': 'aisle',
+            'type': 'Cancel'
           },
           {
-            'name': 'buzz_attract_crater_',
-            'type': 'Capital_junk_pet_dig'
+            'name': 'gym',
+            'type': 'Razor'
           },
           {
-            'name': 'achieve_twenty_found',
-            'type': 'bytes24'
-          },
-          {
-            'name': 'tent_cradle_bamboo_s',
-            'type': 'bytes19'
+            'name': 'drift_patch_cable_bi',
+            'type': 'bytes1'
           }
         ],
-        'Open_either_fetch_gr': [
+        'Expose': [
           {
-            'name': 'afraid_three_silver_',
-            'type': 'string'
-          },
+            'name': 'favorite',
+            'type': 'bytes21'
+          }
+        ],
+        'Cancel': [
           {
-            'name': 'two_wedding_author_a',
+            'name': 'clever',
+            'type': 'uint200'
+          }
+        ],
+        'Razor': [
+          {
+            'name': 'private',
             'type': 'bytes2'
-          },
-          {
-            'name': 'sudden_tail_exclude_',
-            'type': 'bytes11'
-          }
-        ],
-        'Unfair_device_vocal_': [
-          {
-            'name': 'feel_affair_curve_av',
-            'type': 'bytes3'
-          },
-          {
-            'name': 'deer_spoil_indicate_',
-            'type': 'address'
-          }
-        ],
-        'Capital_junk_pet_dig': [
-          {
-            'name': 'return_palace_flock_',
-            'type': 'bytes32'
-          },
-          {
-            'name': 'manage_cement_area_t',
-            'type': 'bytes3'
-          },
-          {
-            'name': 'pole_pluck_odor_circ',
-            'type': 'Open_either_fetch_gr'
           }
         ]
       },
-      'primaryType': 'Primary_Promote_room_donate_',
+      'primaryType': 'Primary_Click',
       'domain': {
-        'name': 'Domain_Census_liberty_own_s',
+        'name': 'Domain_Avocado_luggage_twel',
         'version': '1',
-        'chainId': '0x2207',
-        'verifyingContract': '0x52a3e01d76d2670f8fd452564b3f56eea6fc798d'
+        'chainId': '0x324e',
+        'verifyingContract': '0x69f758a7911448c2f7aa6df15ca27d69ffa1c6b7'
       },
       'message': {
-        'assist_dumb_bubble_g': {
-          'afraid_three_silver_': 'duck_acquire_chaos_rough_leader_merry_symptom_slab_tooth_bachelor_news_produce_bleak_young_skin_toot',
-          'two_wedding_author_a': '0x9604',
-          'sudden_tail_exclude_': '0xf996bed91579769e5bd995',
+        'utility': {
+          'favorite': '0x891b56dc6ab87ab73cf69761183d499283f1925871'
         },
-        'jungle_symptom_meat_': {
-          'feel_affair_curve_av': '0x4f493d',
-          'deer_spoil_indicate_': '0x344b29a452b79bb8e4ef37f2c7688faafd0d2c7d'
+        'aisle': {
+          'clever': '0x0102'
         },
-        'buzz_attract_crater_': {
-          'return_palace_flock_': '0x93012c3a0c21d9adaaa3fb009f06a7bd90449b13df99096f1bdce9c48e16dbec',
-          'manage_cement_area_t': '0x37b91f',
-          'pole_pluck_odor_circ': {
-            'afraid_three_silver_': 'author_never_range_boring_rabbit_meat_notable_excuse_attract_project_east_film_stay_twenty_cause_squ',
-            'two_wedding_author_a': '0xf301',
-            'sudden_tail_exclude_': '0xb5b5f8c2b5120c8aba2497',
-          }
+        'gym': {
+          'private': '0xbb42',
         },
-        'achieve_twenty_found': '0xa5e8c0daacbf617191ec37b0cea3e23b15e4237935733d8c',
-        'tent_cradle_bamboo_s': '0x4bd62f055b4a0ac7f52fe604bd7da4debdd291',
+        'drift_patch_cable_bi': '0xb4'
       }
     }
     const req = {
@@ -1122,6 +1242,7 @@ describe('Test ETH EIP712', function() {
     try {
       await helpers.execute(client, 'sign', req);
     } catch (err) {
+      foundError = true;
       expect(err).to.equal(null)
     }
   })
@@ -1136,5 +1257,5 @@ describe('Test ETH EIP712', function() {
       setTimeout(() => { next(err) }, 2000);
     }
   })
-
+  
 })


### PR DESCRIPTION
`ethers-eip712` required the entire `ethers` library to be included
and, to boot, was incorrect (#215).
We updated firmware to handle this edge case properly and this update
will co-incide with a firmware update.
Closes #215