### PR TITLE
Adds PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What does this do?
+
+<!-- Explain what behavior this PR changes -->
+
+## How does it work?
+
+<!-- Explain how behavior is implemented in code -->
+
+## Examples or References
+
+<!-- Demonstrate the changes to behavior -->
+
+### How to test
+
+<!-- Explain how PR reviewers can test this change themselves -->
+
+## Known Issues
+
+<!-- Share any issues with the changes that you are aware of already -->


### PR DESCRIPTION
## What does this do?

Adds a PR template

## How does it work?

Github looks for the `.github` folder with this exact filename inside of it to create the template when someone creates a PR.

## Examples or References

See the [Github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)

### Testing Locally

Open a PR with the Github web UI from this branch. 

## Known Issues

None.
