### PR TITLE
[TEST] adds isolated/interactive signing and address tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test-btc": "ts-mocha --timeout 180000 -R spec test/testBtc.ts --recursive --exit",
     "test-kv": "ts-mocha --timeout 180000 -R spec test/testKv.ts --recursive --exit",
     "test-wallet-jobs": "ts-mocha --timeout 300000 -R spec test/testWalletJobs.ts --recursive --exit",
-    "test-sigs": "ts-mocha --timeout 300000 -R spec test/testSigs.ts --recursive --exit"
+    "test-sigs": "ts-mocha --timeout 300000 -R spec test/testSigs.ts --recursive --exit",
+    "test-chaos-monkey": "ts-mocha --timeout 300000 -R spec test/testChaosMonkey.ts --recursive --exit"
   },
   "main": "./dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-kv": "ts-mocha --timeout 180000 -R spec test/testKv.ts --recursive --exit",
     "test-wallet-jobs": "ts-mocha --timeout 300000 -R spec test/testWalletJobs.ts --recursive --exit",
     "test-sigs": "ts-mocha --timeout 300000 -R spec test/testSigs.ts --recursive --exit",
-    "test-chaos-monkey": "ts-mocha --timeout 300000 -R spec test/testChaosMonkey.ts --recursive --exit"
+    "test-chaos-monkey": "ts-mocha -R spec test/testChaosMonkey.ts --recursive --exit"
   },
   "main": "./dist/index.js",
   "repository": {

--- a/test/testChaosMonkey.ts
+++ b/test/testChaosMonkey.ts
@@ -72,7 +72,7 @@ const CONNECT_AND_PAIR_LATTICE = (
   //--------------------------------------------------------------------------
   // Connect
   //--------------------------------------------------------------------------
-  client.connect(deviceId, (err, isPaired) => {
+  client.connect(deviceId, (err: any, isPaired: any) => {
     if (err) {
       rej(err)
     } else {
@@ -85,7 +85,7 @@ const CONNECT_AND_PAIR_LATTICE = (
         //--------------------------------------------------------------
         // Pair
         //--------------------------------------------------------------
-        client.pair(pairingCode, (err, isActive) => {
+        client.pair(pairingCode, (err: any, isActive: any) => {
           if (err || !isActive) {
             rej(err || new Error("No active wallet found!"))
           } else {

--- a/test/testChaosMonkey.ts
+++ b/test/testChaosMonkey.ts
@@ -1,0 +1,170 @@
+// Tests for internal Lattice Wallet Jobs
+// NOTE: You must run the following BEFORE executing these tests:
+//
+// 1. Connect with the same deviceID you specfied in 1:
+//
+//    env DEVICE_ID='<your_device_id>' npm test
+//
+// After you do the above, you can run this test with `env DEVICE_ID='<your_device_id>' npm run test-wallet-jobs`
+//
+// NOTE: It is highly suggested that you set `AUTO_SIGN_DEV_ONLY=1` in the firmware
+//        root CMakeLists.txt file (for dev units)
+// To run these tests you will need a dev Lattice with: `FEATURE_TEST_RUNNER=1`
+
+import { Byte } from "bitwise/types";
+import { signingSchema } from "../src/constants";
+
+const { expect } = require('chai');
+const Sdk = require('../src/index');
+const crypto = require('crypto');
+const question = require('readline-sync').question;
+import helpers from './testUtil/helpers';
+
+const REUSABLE_KEY = '3fb53b677f73e4d2b8c89c303f6f6b349f0075ad88ea126cb9f6632085815dca';
+
+//------------------------------------------------------------------------------
+// Connect & Pair – HELPER
+//------------------------------------------------------------------------------
+const CONNECT_AND_PAIR_LATTICE = (
+    env     = process.env,
+    appName = 'Chaos Monkey [Test]',
+    baseUrl = env.baseUrl || 'https://signing.gridpl.us',
+    id      = () => env.DEVICE_ID || question('~ Enter Device ID: '),
+    passwrd = () => env.REUSE_KEY == "1" ? REUSABLE_KEY : question('~ Enter device password: ', {hideEchoBack: true}),
+    secret  = () => question('~ Enter pairing code: ')
+) => new Promise((res, rej) => {
+  console.log("~ Base URL: ", baseUrl);
+  //--------------------------------------------------------------------------
+  // Retrieve 'device ID'
+  //--------------------------------------------------------------------------
+  const deviceId = id()
+
+  //--------------------------------------------------------------------------
+  // Retrieve 'private key'
+  //--------------------------------------------------------------------------
+  const privateKey = (() =>  {
+    const password = passwrd()
+    const privKeyPreImage = Buffer.concat(
+      [
+        Buffer.from(deviceId),
+        Buffer.from(password),
+        Buffer.from(appName)
+      ]
+    )
+    return crypto
+      .createHash('sha256')
+      .update(privKeyPreImage)
+      .digest()
+  })()
+
+  //--------------------------------------------------------------------------
+  // Create 'client'
+  //--------------------------------------------------------------------------
+  const clientOpts = {
+    name: appName,
+    baseUrl: baseUrl,
+    crypto,
+    timeout: 180000,
+    privKey: privateKey
+  }
+  const client = new Sdk.Client(clientOpts)
+
+  //--------------------------------------------------------------------------
+  // Connect
+  //--------------------------------------------------------------------------
+  client.connect(deviceId, (err, isPaired) => {
+    if (err) {
+      rej(err)
+    } else {
+      if (!isPaired) {
+        //--------------------------------------------------------------
+        // Retrieve 'secret pairing code'
+        //--------------------------------------------------------------
+        const pairingCode = secret().toUpperCase()
+
+        //--------------------------------------------------------------
+        // Pair
+        //--------------------------------------------------------------
+        client.pair(pairingCode, (err, isActive) => {
+          if (err || !isActive) {
+            rej(err || new Error("No active wallet found!"))
+          } else {
+            res({ client, deviceId })
+          }
+        })
+      } else {
+        res({ client, deviceId })
+      }
+    }
+  })
+})
+
+const CREATE_HDPATH = (hardened = true, coinType: number = 60, account = 0, index = 0): number[] => {
+  const HARDENED_OFFSET: number = 0x80000000;
+  return `m/44'/${coinType}'/0'/0/0`
+    .split("/")
+    .filter((component) => component != "m")
+    .map((component) => {
+      return Number(component.endsWith('\'') ? Number(component.slice(0, component.length - 1)) + HARDENED_OFFSET : component)
+    })
+}
+
+const SIGN_MESSAGE = (message: string): Promise<any> => {
+  return new Promise((resolved, rejected) => {
+      CONNECT_AND_PAIR_LATTICE().then(context => {
+          const data = {
+              protocol: 'signPersonal',
+              payload: message,
+              signerPath: CREATE_HDPATH(),
+          };
+          const signOpts = {
+              currency: 'ETH_MSG',
+              data: data
+          }
+
+          //@ts-ignore
+          context.client.sign(signOpts, (err: any, signedTx: Object) => {
+              if (err) rejected(err)
+              else resolved(signedTx)
+          })
+      })
+  })
+}
+
+const GET_ADDRESSES = (): Promise<string[]> => {
+  return new Promise((resolved, rejected) => {
+      CONNECT_AND_PAIR_LATTICE().then((context) => {
+        const req = {
+          startPath: CREATE_HDPATH(),
+          n: 2,
+        };
+        console.log(JSON.stringify(req, null, 2))
+
+        //@ts-ignore
+        context.client.getAddresses(req, (err: any, addresses: Object) => {
+          if (err) rejected(err);
+          else resolved(addresses as string[]);
+        });
+      });
+  })
+}
+
+describe("Chaos Monkey", () => {
+  it("Should 1", async () => {
+    const signing   = async () => await SIGN_MESSAGE("This is a message")
+    const addresses = async () => await GET_ADDRESSES()
+    const answer = question(
+      `
+      ~ Run which test? (Timeout in 10 seconds)
+      ~  1. Signature
+      ~  2. Addresses
+      ~  3. Quit
+      `
+    )
+    switch(answer) {
+      case "1": { await signing().then((res) => console.log(`${JSON.stringify(res, null, 2)}`)); return }
+      case "2": { await addresses().then((res) => console.log(JSON.stringify(res, null, 2))); return }
+      default:
+    }
+  });
+});

--- a/test/testChaosMonkey.ts
+++ b/test/testChaosMonkey.ts
@@ -1,11 +1,13 @@
-// Tests for internal Lattice Wallet Jobs
+// Tests for Isolated & Fuzzy SDK testing
 // NOTE: You must run the following BEFORE executing these tests:
 //
 // 1. Connect with the same deviceID you specfied in 1:
 //
-//    env DEVICE_ID='<your_device_id>' npm test
+//    env DEVICE_ID='<your_device_id>' npm run test-chaos-money
 //
-// After you do the above, you can run this test with `env DEVICE_ID='<your_device_id>' npm run test-wallet-jobs`
+// 2. You can optionally specify an `baseUrl`:
+//
+//    env DEVICE_ID='<your_device_id>' baseUrl='<http://local-ip:3000>' npm run test-chaos-money
 //
 // NOTE: It is highly suggested that you set `AUTO_SIGN_DEV_ONLY=1` in the firmware
 //        root CMakeLists.txt file (for dev units)


### PR DESCRIPTION
## Description

This was meant to be a fuzzy testing suite, in due time. However, I've been using this for a few weeks, and it's incredibly helpful to quickly test connection, signing, and addresses stuff in isolation. It's worth sharing with the rest of the team.

## Example

### Signing
```sh
➜  gridplus-sdk git:(kvn/test-chaos-monkey-typescript) DEVICE_ID=K2imh2 baseUrl=10.0.0.103:3000 REUSE_KEY=1 npm run test-chaos-monkey 

> gridplus-sdk@0.9.7 test-chaos-monkey
> ts-mocha --timeout 300000 -R spec test/testChaosMonkey.ts --recursive --exit



  Chaos Monkey

      ~ Run which test? (Timeout in 10 seconds)
      ~  1. Signature
      ~  2. Addresses
      ~  3. Quit
      1
~ Base URL:  10.0.0.103:3000
~ Enter pairing code: xmqd29qf
{
  "sig": {
    "v": {
      "type": "Buffer",
      "data": [
        27
      ]
    },
    "r": "35f88dd82da364236796b292627cb1557d9239084a6afe10fed2e58d1300c14f",
    "s": "7e0d785327ed112f10a031ce4037b7471f6fe03521e28b9d9914b476b52ead5b"
  },
  "signer": {
    "type": "Buffer",
    "data": [
      223,
      12,
      184,
      26,
      29,
      119,
      78,
      105,
      78,
      198,
      95,
      196,
      135,
      6,
      5,
      164,
      190,
      77,
      222,
      34
    ]
  }
}
    ✓ Should 1 (13835ms)


  1 passing (14s)
```

### Addresses
```sh
➜  gridplus-sdk git:(kvn/test-chaos-monkey-typescript) DEVICE_ID=K2imh2 baseUrl=10.0.0.103:3000 REUSE_KEY=1 npm run test-chaos-monkey 

> gridplus-sdk@0.9.7 test-chaos-monkey
> ts-mocha --timeout 300000 -R spec test/testChaosMonkey.ts --recursive --exit



  Chaos Monkey

      ~ Run which test? (Timeout in 10 seconds)
      ~  1. Signature
      ~  2. Addresses
      ~  3. Quit
      2
~ Base URL:  10.0.0.103:3000
{
  "startPath": [
    2147483692,
    2147483708,
    2147483648,
    0,
    0
  ],
  "n": 2
}
[
  "0xdf0cb81a1d774e694ec65fc4870605a4be4dde22",
  "0x579e765becb79e37c72c72402cf6b44a5d474810"
]
```