### PR TITLE
Updates `getAddresses` and adds exportable constants

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'buffer/';
 import superagent from 'superagent';
 import bitcoin from './bitcoin';
 import {
+  GET_ADDR_FLAGS,
   ADDR_STR_LEN,
   ASCII_REGEX,
   BASE_URL,
@@ -263,10 +264,9 @@ export class Client {
    * @category Lattice
    * @returns An array of addresses.
    */
-  public getAddresses (opts: { startPath: number[], n: UInt4 }, cb) {
-    const SKIP_CACHE_FLAG = 1;
+  public getAddresses (opts: { startPath: number[], n: UInt4, flag: Uint4 }, cb) {
     const MAX_ADDR = 10;
-    const { startPath, n } = opts;
+    const { startPath, n, flag = 0 } = opts;
     if (startPath === undefined || n === undefined)
       return cb('Please provide `startPath` and `n` options');
     if (startPath.length < 2 || startPath.length > 5)
@@ -306,21 +306,22 @@ export class Client {
     // Specify the number of subsequent addresses to request.
     // We also allow the user to skip the cache and request any address related to the asset
     // in the wallet.
-    let val;
-    if (true === fwConstants.addrFlagsAllowed) {
-      // Address caching was removed in 0.13.0 so this flag is now deprecated.
-      // All requests against older devices also use the skipFlag=true now.
-      const flag = bitwise.nibble.read(SKIP_CACHE_FLAG);
-      const count = bitwise.nibble.read(n);
-      val = bitwise.byte.write(flag.concat(count) as Byte);
-    } else {
-      val = n;
+    let val = n, flagVal = 0;
+    if (fwConstants.addrFlagsAllowed) {
+      // A 4-bit flag can be used for non-standard address requests
+      // This needs to be combined with `n` as a 4 bit value
+      flagVal = ( fwConstants.getAddressFlags && 
+                  fwConstants.getAddressFlags.indexOf(flag) > -1)
+                ? flag : 0;
+      const flagBits = bitwise.nibble.read(flagVal);
+      const countBits = bitwise.nibble.read(n);
+      val = bitwise.byte.write(flagBits.concat(countBits) as Byte);
     }
     payload.writeUInt8(val, off);
     off++;
     return this._request(payload, 'GET_ADDRESSES', (err, res) => {
       if (err) return cb(err);
-      const parsedRes = this._handleGetAddresses(res);
+      const parsedRes = this._handleGetAddresses(res, flagVal);
       if (parsedRes.err) return cb(parsedRes.err);
       return cb(null, parsedRes.data);
     });
@@ -1122,7 +1123,7 @@ export class Client {
    * @internal
    * @return an array of address strings
    */
-  _handleGetAddresses (encRes) {
+  _handleGetAddresses (encRes, flag) {
     // Handle the encrypted response
     const decrypted = this._handleEncResponse(
       encRes,
@@ -1134,12 +1135,37 @@ export class Client {
     let off = 65; // Skip 65 byte pubkey prefix
     // Look for addresses until we reach the end (a 4 byte checksum)
     const addrs = [];
+    // Pubkeys are formatted differently in the response
+    const isPubkeySet = flag === GET_ADDR_FLAGS.ED25519_PUB || 
+                        flag === GET_ADDR_FLAGS.SECP256K1_PUB;
+    if (isPubkeySet) {
+      off += 1; // skip uint8 representing pubkey type
+    }
     while (off + 4 < decResLengths.getAddresses) {
-      const addrBytes = addrData.slice(off, off + ADDR_STR_LEN);
-      off += ADDR_STR_LEN;
-      // Return the UTF-8 representation
-      const len = addrBytes.indexOf(0); // First 0 is the null terminator
-      if (len > 0) addrs.push(addrBytes.slice(0, len).toString());
+      if (isPubkeySet) {
+        // Pubkeys are shorter and are returned as buffers
+        const pubBytes = addrData.slice(off, off + 65)
+        const isEmpty = pubBytes.every(byte => byte === 0x00);
+        if (!isEmpty && flag === GET_ADDR_FLAGS.ED25519_PUB) {
+          // ED25519 pubkeys are 32 bytes
+          addrs.push(pubBytes.slice(0, 32));
+        } else if (!isEmpty) {
+          // Only other returned pubkeys are ECC, or 65 bytes
+          // Note that we return full (uncompressed) ECC pubkeys
+          addrs.push(pubBytes);
+        }
+        off += 65;
+      } else {
+        // Otherwise we are dealing with address strings
+        const addrBytes = addrData.slice(off, off + ADDR_STR_LEN);
+        off += ADDR_STR_LEN;
+        // Return the UTF-8 representation
+        const len = addrBytes.indexOf(0); // First 0 is the null terminator
+        if (len > 0) {
+          addrs.push(addrBytes.slice(0, len).toString());
+        }
+      }
+      
     }
     return { data: addrs, err: null };
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -289,9 +289,32 @@ const ethMsgProtocol = {
   },
 };
 
-const GET_ADDR_FLAGS = {
-  SECP256K1_PUB: 3,
-  ED25519_PUB: 4,
+//======================================================
+// EXTERNALLY EXPORTED CONSTANTS
+// These are used for building requests
+//======================================================
+export const EXTERNAL = {
+  // Optional flags for `getAddresses`
+  GET_ADDR_FLAGS: {
+    SECP256K1_PUB: 3,
+    ED25519_PUB: 4,
+  },
+  // Options for building general signing requests
+  SIGNING: {
+    HASHES: {
+      NONE: 0,
+      KECCAK256: 1,
+      SHA256: 2,
+    },
+    CURVES: {
+      SECP256K1: 0,
+      ED25519: 1
+    },
+    ENCODINGS: {
+      ASCII: 0,
+      HEX: 1
+    }
+  }
 }
 
 function getFwVersionConst(v) {
@@ -361,13 +384,16 @@ function getFwVersionConst(v) {
     c.genericSigning.baseReqSz = 1552;
     // See `GENERIC_SIGNING_BASE_MSG_SZ` in firmware
     c.genericSigning.baseDataSz = 1519;
-    c.genericSigning.hashTypes = [ 'NONE', 'KECCAK256', 'SHA256' ];
-    c.genericSigning.curveTypes = [ 'SECP256K1', 'ED25519' ];
-    c.genericSigning.encodingTypes = [ 'ASCII', 'HEX' ];
+    c.genericSigning.hashTypes = EXTERNAL.SIGNING.HASHES;
+    c.genericSigning.curveTypes = EXTERNAL.SIGNING.CURVES;
+    c.genericSigning.encodingTypes = EXTERNAL.SIGNING.ENCODINGS;
+    // Supported flags for `getAddresses`
+    c.getAddressFlags = [ 
+      EXTERNAL.GET_ADDR_FLAGS.ED25519_PUB, 
+      EXTERNAL.GET_ADDR_FLAGS.SECP256K1_PUB 
+    ];
     // We updated the max number of params in EIP712 types
     c.eip712MaxTypeParams = 36;
-    // Supported flags for `getAddresses`
-    c.getAddressFlags = [ GET_ADDR_FLAGS.ED25519_PUB, GET_ADDR_FLAGS.SECP256K1_PUB ];
   }
 
   // V0.13.0 added native segwit addresses and fixed a bug in exporting
@@ -436,7 +462,6 @@ function getFwVersionConst(v) {
 const ASCII_REGEX = /^[\x00-\x7F]+$/;
 
 export {
-  GET_ADDR_FLAGS,
   ASCII_REGEX,
   getFwVersionConst,
   ADDR_STR_LEN,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -289,6 +289,11 @@ const ethMsgProtocol = {
   },
 };
 
+const GET_ADDR_FLAGS = {
+  SECP256K1_PUB: 3,
+  ED25519_PUB: 4,
+}
+
 function getFwVersionConst(v) {
   const c: any = {
     extraDataFrameSz: 0,
@@ -344,7 +349,7 @@ function getFwVersionConst(v) {
 
   // V0.14.0 added support for a more robust API around ABI definitions
   // and generic signing functionality
-  if (!legacy && gte(v, [0, 14, 0])) {
+  if (!legacy && gte(v, [0, 13, 0])) {
     // Size of `category` buffer. Inclusive of null terminator byte.
     c.abiCategorySz = 32;
     c.abiMaxRmv = 200;  // Max number of ABI defs that can be removed with
@@ -359,9 +364,10 @@ function getFwVersionConst(v) {
     c.genericSigning.hashTypes = [ 'NONE', 'KECCAK256', 'SHA256' ];
     c.genericSigning.curveTypes = [ 'SECP256K1', 'ED25519' ];
     c.genericSigning.encodingTypes = [ 'ASCII', 'HEX' ];
-
     // We updated the max number of params in EIP712 types
     c.eip712MaxTypeParams = 36;
+    // Supported flags for `getAddresses`
+    c.getAddressFlags = [ GET_ADDR_FLAGS.ED25519_PUB, GET_ADDR_FLAGS.SECP256K1_PUB ];
   }
 
   // V0.13.0 added native segwit addresses and fixed a bug in exporting
@@ -430,6 +436,7 @@ function getFwVersionConst(v) {
 const ASCII_REGEX = /^[\x00-\x7F]+$/;
 
 export {
+  GET_ADDR_FLAGS,
   ASCII_REGEX,
   getFwVersionConst,
   ADDR_STR_LEN,

--- a/src/genericSigning.ts
+++ b/src/genericSigning.ts
@@ -28,6 +28,10 @@ export const buildGenericSigningMsgRequest = function(req) {
   } = fwConstants;
   const { curveTypes, encodingTypes, hashTypes, baseDataSz, baseReqSz } = genericSigning;
   try {
+    if (typeof hashType !== 'string' || typeof curveType !== 'string') {
+      throw new Error('hashType and curveType must be included as strings.')
+    }
+
     const HASH_T = hashType.toUpperCase();
     const CURVE_T = curveType.toUpperCase();
     const curveIdx = curveTypes.indexOf(CURVE_T);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { Client } from './client';
+export { EXTERNAL as Constants } from './constants'

--- a/src/util.ts
+++ b/src/util.ts
@@ -263,3 +263,8 @@ export const isAsciiStr = function(str, allowFormatChars=false) {
   }
   return true;
 }
+
+// Check if a value exists in an object. Only checks first level of keys.
+export const existsIn = function(val, obj) {
+  return Object.keys(obj).some(key => obj[key] === val);
+}

--- a/test/testAll.ts
+++ b/test/testAll.ts
@@ -59,7 +59,6 @@ describe('Connect and Pair', () => {
     if (caughtErr === false) {
       const fwConstants = getFwVersionConst(client.fwVersion);
       const addrData = {
-        currency: 'BTC',
         startPath: [
           helpers.BTC_PURPOSE_P2SH_P2WPKH,
           helpers.BTC_COIN,
@@ -87,7 +86,6 @@ describe('Connect and Pair', () => {
       // If firmware supports it, try shorter paths
       if (fwConstants.flexibleAddrPaths) {
         const flexData = {
-          currency: 'ETH',
           startPath: [
             helpers.BTC_PURPOSE_P2PKH,
             helpers.ETH_COIN,

--- a/test/testUtil/helpers.ts
+++ b/test/testUtil/helpers.ts
@@ -3,12 +3,14 @@ import { wordlists } from 'bip39';
 import bitcoin from 'bitcoinjs-lib';
 import { expect as expect } from 'chai';
 import crypto from 'crypto';
-import { derivePath as deriveEDKey } from 'ed25519-hd-key'
+import { derivePath as deriveEDKey, getPublicKey as getEDPubkey } from 'ed25519-hd-key'
 import { ec as EC, eddsa as EdDSA } from 'elliptic';
 import { privateToAddress } from 'ethereumjs-util';
 import { keccak256 } from 'js-sha3';
 import { sha256 } from 'hash.js/lib/hash/sha'
-import { ADDR_STR_LEN, BIP_CONSTANTS, ethMsgProtocol, HARDENED_OFFSET } from '../../src/constants';
+import { 
+  ADDR_STR_LEN, BIP_CONSTANTS, ethMsgProtocol, HARDENED_OFFSET, GET_ADDR_FLAGS, 
+} from '../../src/constants';
 import { Client } from '../../src/index';
 import { ensureHexBuffer, parseDER } from '../../src/util';
 const SIGHASH_ALL = 0x01;
@@ -329,6 +331,24 @@ export const harden = (x) => {
   return x + HARDENED_OFFSET;
 };
 
+export const prandomBuf = function(prng, maxSz, forceSize=false) {
+  // Build a random payload that can fit in the base request
+  const sz = forceSize ? maxSz : Math.floor(maxSz * prng.quick());
+  const buf = Buffer.alloc(sz);
+  for (let i = 0; i < sz; i++) {
+    buf[i] = Math.floor(0xff * prng.quick());
+  }
+  return buf;
+}
+
+export const deriveED25519Key = function(path, seed) {
+  const { key } = deriveEDKey(getPathStr(path), seed);
+  const pub = getEDPubkey(key, false); // `false` removes the leading zero byte
+  return {
+    priv: key,
+    pub,
+  }
+}
 
 //============================================================
 // Wallet Job integration test helpers
@@ -527,7 +547,7 @@ export const serializeGetAddressesJobData = function (data) {
   req.writeUInt32LE(data.count, off);
   off += 4;
   // Deprecated skipCache flag. It isn't used by firmware anymore.
-  req.writeUInt8(1, off);
+  req.writeUInt8(data.flag || 0, off);
   return req;
 };
 
@@ -537,8 +557,10 @@ export const deserializeGetAddressesJobResult = function (res) {
     count: null,
     addresses: [],
   };
-  getAddrResult.count = res.readUInt32LE(off);
-  off += 4;
+  getAddrResult.pubOnly = res.readUint8(off);
+  off += 1;
+  getAddrResult.count = res.readUint8(off);
+  off += 3; // Skip a 2-byte empty shim value (for backwards compatibility)
   for (let i = 0; i < getAddrResult.count; i++) {
     const _addr = res.slice(off, off + ADDR_STR_LEN);
     off += ADDR_STR_LEN;
@@ -597,6 +619,30 @@ export const validateETHAddresses = function (resp, jobData, seed) {
     expect(addr).to.equal(resp.addresses[i - jobData.first]);
   }
 };
+
+export const validateDerivedPublicKeys = function(pubKeys, firstPath, seed, flag=null) {
+  const wallet = bip32.fromSeed(seed);
+  // We assume the keys were derived in sequential order
+  pubKeys.forEach((pub, i) => {
+    const path = JSON.parse(JSON.stringify(firstPath));
+    path[path.length - 1] += i;
+    if (flag === GET_ADDR_FLAGS.ED25519_PUB) {
+      // ED25519 requires its own derivation
+      const key = deriveED25519Key(path, seed);
+      expect(pub.toString('hex')) 
+      .to
+      .equal(key.pub.toString('hex'), 
+            'Exported ED25519 pubkey incorrect');
+    } else {
+      // Otherwise this is a SECP256K1 pubkey
+      const priv = wallet.derivePath(getPathStr(path)).privateKey;
+      expect(pub.toString('hex'))
+      .to
+      .equal( secp256k1.keyFromPrivate(priv).getPublic().encode('hex'),
+              'Exported SECP256K1 pubkey incorrect');
+    }
+  })
+}
 
 export const ethPersonalSignMsg = function(msg) {
   return '\u0019Ethereum Signed Message:\n' + String(msg.length) + msg;
@@ -872,7 +918,7 @@ export const validateGenericSig = function(seed, sig, data) {
     if (hashType !== 'NONE') {
       throw new Error('Bad params');
     }
-    const { key: priv } = deriveEDKey(getPathStr(signerPath), seed);
+    const { priv } = deriveED25519Key(signerPath, seed);
     const key = ed25519.keyFromSecret(priv);
     const formattedSig = `${sig.r.toString('hex')}${sig.s.toString('hex')}`
     expect(key.verify(payloadBuf, formattedSig)).to.equal(true, 'Signature failed verification.')
@@ -908,6 +954,7 @@ export default {
   deserializeGetAddressesJobResult,
   validateBTCAddresses,
   validateETHAddresses,
+  validateDerivedPublicKeys,
   ethPersonalSignMsg,
   serializeSignTxJobDataLegacy,
   deserializeSignTxJobResult,
@@ -917,4 +964,6 @@ export default {
   serializeLoadSeedJobData,
   buildRandomEip712Object,
   validateGenericSig,
+  deriveED25519Key,
+  prandomBuf,
 }

--- a/test/testWalletJobs.ts
+++ b/test/testWalletJobs.ts
@@ -23,7 +23,8 @@ import { ecrecover, privateToAddress, privateToPublic, publicToAddress } from 'e
 import { keccak256 } from 'js-sha3';
 import { decode, encode } from 'rlp';
 import seedrandom from 'seedrandom';
-import { getFwVersionConst, HARDENED_OFFSET, GET_ADDR_FLAGS } from '../src/constants';
+import { getFwVersionConst, HARDENED_OFFSET } from '../src/constants';
+import { Constants } from '../src/index'
 import helpers from './testUtil/helpers';
 let client,
   currentWalletUID,
@@ -554,7 +555,7 @@ describe('getAddresses', () => {
     const req = {
       startPath: [helpers.BTC_PURPOSE_P2SH_P2WPKH, helpers.ETH_COIN, HARDENED_OFFSET, 0, 0],
       n: 3,
-      flag: GET_ADDR_FLAGS.SECP256K1_PUB,
+      flag: Constants.GET_ADDR_FLAGS.SECP256K1_PUB,
     };
     continueTests = false;
     try {
@@ -571,7 +572,7 @@ describe('getAddresses', () => {
     const req = {
       startPath: [helpers.BTC_PURPOSE_P2SH_P2WPKH, helpers.ETH_COIN, 0],
       n: 3,
-      flag: GET_ADDR_FLAGS.ED25519_PUB,
+      flag: Constants.GET_ADDR_FLAGS.ED25519_PUB,
     };
     continueTests = false;
     try {


### PR DESCRIPTION
Corresponds to firmware changes: https://github.com/GridPlus/k8x_firmware_production/pull/2347

* Updates format for `getAddresses` to allow export of public keys rather than addresses. Pubkeys returned are buffers (though I could be persuaded to change this to hex strings). This is needed because Solana "addresses" are actually just base58-encoded pubkeys on the ED25519 curve. This also opens the door to exporting root pubkeys for in-app derivation, though currently that is blocked by firmware requiring at least 2 derivation indices.
* Adds a new category of constants (exported by `index.js` as `Constants`) which are used to build requests (see examples in the tests of this PR). We should probably clean up `constants.js` further but I wanted to start the process of making some exportable.