### PR TITLE
Makes updating of sig.v for Ethereum transactions more explicit

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1311,18 +1311,18 @@ export class Client {
         sigs,
       };
     } else if (currencyType === 'ETH') {
-      const sig: any = parseDER(res.slice(off, off + 2 + res[off + 1]));
+      const sig = parseDER(res.slice(off, off + 2 + res[off + 1]));
       off += DERLength;
       const ethAddr = res.slice(off, off + 20);
       // Determine the `v` param and add it to the sig before returning
-      const rawTx = ethereum.buildEthRawTx(req, sig, ethAddr);
+      const { rawTx, sigWithV } = ethereum.buildEthRawTx(req, sig, ethAddr);
       return {
         tx: `0x${rawTx}`,
         txHash: `0x${ethereum.hashTransaction(rawTx)}`,
         sig: {
-          v: sig.v,
-          r: sig.r.toString('hex'),
-          s: sig.s.toString('hex'),
+          v: sigWithV.v,
+          r: sigWithV.r.toString('hex'),
+          s: sigWithV.s.toString('hex'),
         },
         signer: ethAddr,
       };

--- a/src/ethereum.ts
+++ b/src/ethereum.ts
@@ -418,7 +418,7 @@ const buildEthRawTx = function (tx, sig, address) {
       rlpEncodedWithSig,
     ]);
   }
-  return rlpEncodedWithSig.toString('hex');
+  return { rawTx: rlpEncodedWithSig.toString('hex'), sigWithV: newSig }
 };
 
 // Attach a recovery parameter to a signature by brute-forcing ECRecover


### PR DESCRIPTION
`sig` *is* updated to have a `v` property two function calls deeper in `ethereum.addRecoveryParam()`, but this makes that change explicit by returning the updated `sig` object and using that object to build the response.