### PR TITLE
Test cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "ed25519-hd-key": "^1.2.0",
         "eslint": "^8.7.0",
         "ethereumjs-util": "^7.1.0",
-        "it-each": "^0.4.0",
         "lodash": ">=4.17.21",
         "minimist": ">=0.2.1",
         "mocha": "^9.2.0",
@@ -1955,12 +1954,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dot-notes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/dot-notes/-/dot-notes-3.1.1.tgz",
-      "integrity": "sha1-eufhqUgTRSnzdosvsT9Mj6kqV88=",
-      "dev": true
-    },
     "node_modules/ed25519-hd-key": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ed25519-hd-key/-/ed25519-hd-key-1.2.0.tgz",
@@ -2901,15 +2894,6 @@
       "dev": true,
       "peerDependencies": {
         "ws": "*"
-      }
-    },
-    "node_modules/it-each": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/it-each/-/it-each-0.4.0.tgz",
-      "integrity": "sha512-fbOxSUiOByQnkgoFUEKPfzAuoUZ0mQRAXdWWsfI53gMJZ2oyhPcJBOCFx8yuMM36yP6OUUL3LgilYEqBiSACmQ==",
-      "dev": true,
-      "dependencies": {
-        "dot-notes": "3.1.1"
       }
     },
     "node_modules/jayson": {
@@ -5993,12 +5977,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dot-notes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/dot-notes/-/dot-notes-3.1.1.tgz",
-      "integrity": "sha1-eufhqUgTRSnzdosvsT9Mj6kqV88=",
-      "dev": true
-    },
     "ed25519-hd-key": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ed25519-hd-key/-/ed25519-hd-key-1.2.0.tgz",
@@ -6723,15 +6701,6 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "dev": true,
       "requires": {}
-    },
-    "it-each": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/it-each/-/it-each-0.4.0.tgz",
-      "integrity": "sha512-fbOxSUiOByQnkgoFUEKPfzAuoUZ0mQRAXdWWsfI53gMJZ2oyhPcJBOCFx8yuMM36yP6OUUL3LgilYEqBiSACmQ==",
-      "dev": true,
-      "requires": {
-        "dot-notes": "3.1.1"
-      }
     },
     "jayson": {
       "version": "3.6.6",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "ed25519-hd-key": "^1.2.0",
     "eslint": "^8.7.0",
     "ethereumjs-util": "^7.1.0",
-    "it-each": "^0.4.0",
     "lodash": ">=4.17.21",
     "minimist": ">=0.2.1",
     "mocha": "^9.2.0",

--- a/test/testAbi.ts
+++ b/test/testAbi.ts
@@ -1,4 +1,3 @@
-require('it-each')({ testPerIteration: true });
 import { AbiCoder } from '@ethersproject/abi';
 import { expect } from 'chai';
 import crypto from 'crypto';
@@ -23,19 +22,12 @@ const uintTypes = ['uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256'];
 let client = null;
 let continueTests = true;
 let NUM_DEFS_SAVED = 0;
-
-// Definitions and indices (the latter are used with it.each and must be defined at the
-// top of the file).
 // Boundary conditions are tested with `boundaryAbiDefs` and random definitions are
 // filled into `abiDefs`.
 const boundaryAbiDefs = [];
-const boundaryIndices = [];
 createBoundaryDefs();
 const abiDefs = [];
 const tupleAbiDefs = [];
-const indices = [];
-for (let i = 0; i < boundaryAbiDefs.length; i++) boundaryIndices.push({ i });
-for (let i = 0; i < numIter; i++) indices.push({ i });
 
 // Transaction params
 const txData = {
@@ -570,7 +562,7 @@ describe('Setup client', () => {
   it('Should setup the test client', () => {
     client = helpers.setupTestClient(process.env);
     expect(client).to.not.equal(null);
-  });
+  })
 
   it('Should connect to a Lattice and make sure it is already paired.', async () => {
     // Again, we assume that if an `id` has already been set, we are paired
@@ -580,8 +572,8 @@ describe('Setup client', () => {
     expect(connectErr).to.equal(null);
     expect(client.isPaired).to.equal(true);
     expect(client.hasActiveWallet()).to.equal(true);
-  });
-});
+  })
+})
 
 describe('Test ABI fetch, create, delete', () => {
   const TEST_DEF = {
@@ -747,7 +739,7 @@ describe('Preloaded ABI definitions', () => {
         _vals: ['0x39b657f4d86119e11de818e477a31c13feeb618c', 1234],
       },
     ];
-    erc20PreloadedDefs.forEach((def: any) => {
+    erc20PreloadedDefs.forEach((def) => {
       def._typeNames = getTypeNames(def.params);
       def.sig = buildFuncSelector(def);
     });
@@ -776,19 +768,19 @@ describe('Preloaded ABI definitions', () => {
       continueTests = false;
       expect(err).to.equal(null, err.message);
     }
-  });
-});
+  })
+})
 
 describe('Add ABI definitions', () => {
   let defsToLoad = [];
   beforeEach(() => {
     expect(continueTests).to.equal(true, 'Prior test failed. Aborting.');
-  });
+  })
 
   it(`Should generate and add ${numIter} ABI definitions to the Lattice`, async () => {
     try {
       for (let iter = 0; iter < numIter; iter++) {
-        const def: any = createDef();
+        const def = createDef();
         abiDefs.push(def);
         defsToLoad.push(def);
       }
@@ -796,12 +788,12 @@ describe('Add ABI definitions', () => {
       continueTests = false;
       expect(err).to.equal(null, err);
     }
-  });
+  })
 
   it(`Should generate and add ${numIter} tuple-based ABI defintions to the Lattice`, async () => {
     try {
       for (let iter = 0; iter < numIter; iter++) {
-        const def: any = createTupleDef();
+        const def = createTupleDef();
         tupleAbiDefs.push(def);
         defsToLoad.push(def);
       }
@@ -809,7 +801,7 @@ describe('Add ABI definitions', () => {
       continueTests = false;
       expect(err).to.equal(null, err);
     }
-  });
+  })
 
   it('Should test parsing of a 0x V2 ABI via Etherscan', async () => {
     const funcDef = {
@@ -909,7 +901,7 @@ describe('Add ABI definitions', () => {
     }
     const newDefs = abi.abiParsers.etherscan([funcDef]);
     defsToLoad = defsToLoad.concat(newDefs);
-  });
+  })
 
   it('Should add the ABI definitions', async () => {
     try {
@@ -923,21 +915,21 @@ describe('Add ABI definitions', () => {
       continueTests = false;
       expect(err).to.equal(null, err);
     }
-  });
-});
+  })
+})
 
 describe('Test ABI Markdown', () => {
   beforeEach(() => {
     expect(continueTests).to.equal(true, 'Prior test failed. Aborting.');
     req.data.data = null;
-  });
+  })
 
   it('Should inform the user what to do', async () => {
     question(
       'Please APPROVE all ABI-decoded payloads and REJECT all unformatted ones. Make sure the type matches the function name! Press enter.'
     );
     expect(true).to.equal(true);
-  });
+  })
 
   it('Should pass when variable arraySz is 0', async () => {
     const bytesDef = _.cloneDeep(boundaryAbiDefs[9]);
@@ -949,7 +941,7 @@ describe('Test ABI Markdown', () => {
       continueTests = false;
       expect(err).to.not.equal(null, err);
     }
-  });
+  })
 
   it('Should pass when dynamic param has size 0', async () => {
     const bytesDef = _.cloneDeep(boundaryAbiDefs[9]);
@@ -962,80 +954,56 @@ describe('Test ABI Markdown', () => {
       continueTests = false;
       expect(err).to.not.equal(null, err);
     }
-  });
+  })
 
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    boundaryIndices,
-    'Test ABI markdown of boundary conditions #%s',
-    ['i'],
-    async (n, next) => {
-      const def: any = boundaryAbiDefs[n.i];
-      req.data.data = buildEthData(def);
-      try {
-        const sigResp: any = await helpers.execute(client, 'sign', req);
+  it('Should test ABI markdown of boundary contitions', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < boundaryAbiDefs.length; i++) {
+        const def = boundaryAbiDefs[i];
+        req.data.data = buildEthData(def);
+        const sigResp = await helpers.execute(client, 'sign', req);
         expect(sigResp.tx).to.not.equal(null);
         expect(sigResp.txHash).to.not.equal(null);
-        setTimeout(() => {
-          next();
-        }, 1000);
-      } catch (err) {
-        continueTests = false;
-        setTimeout(() => {
-          next(err);
-        }, 1000);
       }
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
+  })
 
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    indices,
-    'Test ABI markdown of payload #%s (non-tuple)',
-    ['i'],
-    async (n, next) => {
-      const def: any = abiDefs[n.i];
-      req.data.data = buildEthData(def);
-      try {
-        const sigResp: any = await helpers.execute(client, 'sign', req);
+  it('Should test ABI markdown of random payloads (non-tuple)', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < abiDefs.length; i++) {
+        const def = abiDefs[n.i];
+        req.data.data = buildEthData(def);
+        const sigResp = await helpers.execute(client, 'sign', req);
         expect(sigResp.tx).to.not.equal(null);
         expect(sigResp.txHash).to.not.equal(null);
-        setTimeout(() => {
-          next();
-        }, 1000);
-      } catch (err) {
-        continueTests = false;
-        setTimeout(() => {
-          next(err);
-        }, 1000);
-      }
+      } 
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
+  })
 
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    indices,
-    'Test ABI markdown of payload #%s (tuple)',
-    ['i'],
-    async (n, next) => {
-      const def: any = tupleAbiDefs[n.i];
-      req.data.data = buildEthData(def);
-      try {
-        const sigResp: any = await helpers.execute(client, 'sign', req);
+  it('Should test ABI markdown of random payloads (tuple)', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < tupleAbiDefs.length; i++) {
+        const def = tupleAbiDefs[n.i];
+        req.data.data = buildEthData(def);
+        const sigResp = await helpers.execute(client, 'sign', req);
         expect(sigResp.tx).to.not.equal(null);
         expect(sigResp.txHash).to.not.equal(null);
-        setTimeout(() => {
-          next();
-        }, 1000);
-      } catch (err) {
-        continueTests = false;
-        setTimeout(() => {
-          next(err);
-        }, 1000);
       }
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-});
+  })
+})
 
 describe('Cleanup', () => {
   let records;

--- a/test/testAbi.ts
+++ b/test/testAbi.ts
@@ -976,7 +976,7 @@ describe('Test ABI Markdown', () => {
     try {
       continueTests = false;
       for (let i = 0; i < abiDefs.length; i++) {
-        const def = abiDefs[n.i];
+        const def = abiDefs[i];
         req.data.data = buildEthData(def);
         const sigResp = await helpers.execute(client, 'sign', req);
         expect(sigResp.tx).to.not.equal(null);
@@ -992,7 +992,7 @@ describe('Test ABI Markdown', () => {
     try {
       continueTests = false;
       for (let i = 0; i < tupleAbiDefs.length; i++) {
-        const def = tupleAbiDefs[n.i];
+        const def = tupleAbiDefs[i];
         req.data.data = buildEthData(def);
         const sigResp = await helpers.execute(client, 'sign', req);
         expect(sigResp.tx).to.not.equal(null);

--- a/test/testAll.ts
+++ b/test/testAll.ts
@@ -6,6 +6,7 @@ import helpers from './testUtil/helpers';
 
 let client, id;
 let caughtErr = false;
+let continueTests = true;
 
 describe('Connect and Pair', () => {
   before(() => {
@@ -13,533 +14,590 @@ describe('Connect and Pair', () => {
     if (process.env.DEVICE_ID) id = process.env.DEVICE_ID;
   });
 
+  beforeEach(() => {
+    expect(continueTests).to.equal(true, 'Error found in prior test. Aborting.');
+  })
+
+
   //-------------------------------------------
   // TESTS
   //-------------------------------------------
   it('Should connect to a Lattice', async () => {
-    // Again, we assume that if an `id` has already been set, we are paired
-    // with the hardcoded privkey above.
-    if (!process.env.DEVICE_ID) {
-      const _id = question('Please enter the ID of your test device: ');
-      id = _id;
-      const connectErr = await helpers.connect(client, id);
-      caughtErr = connectErr !== null;
-      expect(connectErr).to.equal(null);
-      expect(client.isPaired).to.equal(false);
-      expect(client.hasActiveWallet()).to.equal(false);
+    try {
+      continueTests = false;
+      // Again, we assume that if an `id` has already been set, we are paired
+      // with the hardcoded privkey above.
+      if (!process.env.DEVICE_ID) {
+        const _id = question('Please enter the ID of your test device: ');
+        id = _id;
+        const connectErr = await helpers.connect(client, id);
+        caughtErr = connectErr !== null;
+        expect(connectErr).to.equal(null);
+        expect(client.isPaired).to.equal(false);
+        expect(client.hasActiveWallet()).to.equal(false);
+      }
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
   });
 
   it('Should attempt to pair with pairing secret', async () => {
-    if (!process.env.DEVICE_ID) {
-      expect(caughtErr).to.equal(false);
-      if (caughtErr === false) {
+    try {
+      continueTests = false;
+      if (!process.env.DEVICE_ID) {
         const secret = question('Please enter the pairing secret: ');
         const pairErr = await helpers.pair(client, secret);
-        caughtErr = pairErr !== null;
         expect(pairErr).to.equal(null);
         expect(client.hasActiveWallet()).to.equal(true);
       }
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
   });
 
   it('Should try to connect again but recognize the pairing already exists', async () => {
-    expect(caughtErr).to.equal(false);
-    if (caughtErr === false) {
+    try {
+      continueTests = false;
       const connectErr = await helpers.connect(client, id);
-      caughtErr = connectErr !== null;
       expect(connectErr).to.equal(null);
       expect(client.isPaired).to.equal(true);
       expect(client.hasActiveWallet()).to.equal(true);
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
   });
 
   it('Should get addresses', async () => {
-    expect(caughtErr).to.equal(false);
-    if (caughtErr === false) {
-      const fwConstants = getFwVersionConst(client.fwVersion);
-      const addrData = {
-        startPath: [
-          helpers.BTC_PURPOSE_P2SH_P2WPKH,
-          helpers.BTC_COIN,
-          HARDENED_OFFSET,
-          0,
-          0,
-        ],
-        n: 5,
-      };
-      // Bitcoin addresses
-      // NOTE: The format of address will be based on the user's Lattice settings
-      //       By default, this will be P2SH(P2WPKH), i.e. addresses that start with `3`
-      let addrs;
-      addrs = await helpers.execute(client, 'getAddresses', addrData);
-      expect(addrs.length).to.equal(5);
-      expect(addrs[0][0]).to.equal('3');
-
-      // Ethereum addresses
-      addrData.startPath[0] = helpers.BTC_PURPOSE_P2PKH;
-      addrData.startPath[1] = helpers.ETH_COIN;
-      addrData.n = 1;
-      addrs = await helpers.execute(client, 'getAddresses', addrData);
-      expect(addrs.length).to.equal(1);
-      expect(addrs[0].slice(0, 2)).to.equal('0x');
-      // If firmware supports it, try shorter paths
-      if (fwConstants.flexibleAddrPaths) {
-        const flexData = {
+    try {
+      continueTests = false;
+      expect(caughtErr).to.equal(false);
+      if (caughtErr === false) {
+        const fwConstants = getFwVersionConst(client.fwVersion);
+        const addrData = {
           startPath: [
-            helpers.BTC_PURPOSE_P2PKH,
-            helpers.ETH_COIN,
+            helpers.BTC_PURPOSE_P2SH_P2WPKH,
+            helpers.BTC_COIN,
             HARDENED_OFFSET,
             0,
+            0,
           ],
-          n: 1,
+          n: 5,
         };
-        addrs = await helpers.execute(client, 'getAddresses', flexData);
+        // Bitcoin addresses
+        // NOTE: The format of address will be based on the user's Lattice settings
+        //       By default, this will be P2SH(P2WPKH), i.e. addresses that start with `3`
+        let addrs;
+        addrs = await helpers.execute(client, 'getAddresses', addrData);
+        expect(addrs.length).to.equal(5);
+        expect(addrs[0][0]).to.equal('3');
+
+        // Ethereum addresses
+        addrData.startPath[0] = helpers.BTC_PURPOSE_P2PKH;
+        addrData.startPath[1] = helpers.ETH_COIN;
+        addrData.n = 1;
+        addrs = await helpers.execute(client, 'getAddresses', addrData);
         expect(addrs.length).to.equal(1);
         expect(addrs[0].slice(0, 2)).to.equal('0x');
-      }
+        // If firmware supports it, try shorter paths
+        if (fwConstants.flexibleAddrPaths) {
+          const flexData = {
+            startPath: [
+              helpers.BTC_PURPOSE_P2PKH,
+              helpers.ETH_COIN,
+              HARDENED_OFFSET,
+              0,
+            ],
+            n: 1,
+          };
+          addrs = await helpers.execute(client, 'getAddresses', flexData);
+          expect(addrs.length).to.equal(1);
+          expect(addrs[0].slice(0, 2)).to.equal('0x');
+        }
 
-      // Bitcoin testnet
-      addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
-      addrData.startPath[1] = helpers.BTC_TESTNET_COIN;
-      addrData.n = 1;
-      addrs = await helpers.execute(client, 'getAddresses', addrData);
-      expect(addrs.length).to.equal(1);
-      expect(addrs[0][0]).to.be.oneOf(['n', 'm', '2']);
-      addrData.startPath[1] = helpers.BTC_COIN;
-
-      // Bech32
-      addrData.startPath[0] = helpers.BTC_PURPOSE_P2WPKH;
-      addrData.n = 1;
-      addrs = await helpers.execute(client, 'getAddresses', addrData);
-      expect(addrs.length).to.equal(1);
-      expect(addrs[0].slice(0, 3)).to.be.oneOf(['bc1']);
-      addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
-      addrData.n = 5;
-
-      addrData.startPath[4] = 1000000;
-      addrData.n = 3;
-      addrs = await helpers.execute(client, 'getAddresses', addrData);
-      expect(addrs.length).to.equal(addrData.n);
-      addrData.startPath[4] = 0;
-      addrData.n = 1;
-
-      // Unsupported purpose (m/<purpose>/)
-      addrData.startPath[0] = 0; // Purpose 0 -- undefined
-      try {
+        // Bitcoin testnet
+        addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
+        addrData.startPath[1] = helpers.BTC_TESTNET_COIN;
+        addrData.n = 1;
         addrs = await helpers.execute(client, 'getAddresses', addrData);
-        expect(addrs).to.equal(null);
-      } catch (err) {
-        expect(err).to.not.equal(null);
-      }
-      addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
+        expect(addrs.length).to.equal(1);
+        expect(addrs[0][0]).to.be.oneOf(['n', 'm', '2']);
+        addrData.startPath[1] = helpers.BTC_COIN;
 
-      // Unsupported currency
-      addrData.startPath[1] = HARDENED_OFFSET + 5; // 5' currency - aka unknown
-      try {
+        // Bech32
+        addrData.startPath[0] = helpers.BTC_PURPOSE_P2WPKH;
+        addrData.n = 1;
         addrs = await helpers.execute(client, 'getAddresses', addrData);
-        expect(addrs).to.equal(null);
-      } catch (err) {
-        expect(err).to.not.equal(null);
-      }
-      addrData.startPath[1] = helpers.BTC_COIN;
-      // Too many addresses (n>10)
-      addrData.n = 11;
-      try {
+        expect(addrs.length).to.equal(1);
+        expect(addrs[0].slice(0, 3)).to.be.oneOf(['bc1']);
+        addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
+        addrData.n = 5;
+
+        addrData.startPath[4] = 1000000;
+        addrData.n = 3;
         addrs = await helpers.execute(client, 'getAddresses', addrData);
-        expect(addrs).to.equal(null);
-      } catch (err) {
-        expect(err).to.not.equal(null);
+        expect(addrs.length).to.equal(addrData.n);
+        addrData.startPath[4] = 0;
+        addrData.n = 1;
+
+        // Unsupported purpose (m/<purpose>/)
+        addrData.startPath[0] = 0; // Purpose 0 -- undefined
+        try {
+          addrs = await helpers.execute(client, 'getAddresses', addrData);
+          expect(addrs).to.equal(null);
+        } catch (err) {
+          expect(err).to.not.equal(null);
+        }
+        addrData.startPath[0] = helpers.BTC_PURPOSE_P2SH_P2WPKH;
+
+        // Unsupported currency
+        addrData.startPath[1] = HARDENED_OFFSET + 5; // 5' currency - aka unknown
+        try {
+          addrs = await helpers.execute(client, 'getAddresses', addrData);
+          expect(addrs).to.equal(null);
+        } catch (err) {
+          expect(err).to.not.equal(null);
+        }
+        addrData.startPath[1] = helpers.BTC_COIN;
+        // Too many addresses (n>10)
+        addrData.n = 11;
+        try {
+          addrs = await helpers.execute(client, 'getAddresses', addrData);
+          expect(addrs).to.equal(null);
+        } catch (err) {
+          expect(err).to.not.equal(null);
+        }
       }
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
   });
 
   it('Should sign Ethereum transactions', async () => {
-    // Constants from firmware
-    const fwConstants = getFwVersionConst(client.fwVersion);
-    const GAS_PRICE_MAX = fwConstants.ethMaxGasPrice;
-    const GAS_LIMIT_MIN = 22000;
-    const GAS_LIMIT_MAX = 12500000;
-
-    const txData = {
-      nonce: '0x02',
-      gasPrice: '0x1fe5d61a00',
-      gasLimit: '0x034e97',
-      to: '0x1af768c0a217804cfe1a0fb739230b546a566cd6',
-      value: '0x01cba1761f7ab9870c',
-      data: '0x17e914679b7e160613be4f8c2d3203d236286d74eb9192f6d6f71b9118a42bb033ccd8e8',
-    };
-    const req: any = {
-      currency: 'ETH',
-      data: {
-        signerPath: [
-          helpers.BTC_PURPOSE_P2PKH,
-          helpers.ETH_COIN,
-          HARDENED_OFFSET,
-          0,
-          0,
-        ],
-        ...txData,
-        chainId: 'rinkeby', // Can also be an integer
-      },
-    };
-    // Sign a tx that does not use EIP155 (no EIP155 on rinkeby for some reason)
-    let tx;
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-
-    // Sign a tx with EIP155
-    req.data.chainId = 'mainnet';
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-    req.data.chainId = 'rinkeby';
-
-    req.data.data = client.crypto
-      .randomBytes(fwConstants.ethMaxDataSz)
-      .toString('hex');
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-    req.data.data = null;
-
-    // Invalid chainId
-    req.data.chainId = 'notachain';
     try {
+      continueTests = false;
+      // Constants from firmware
+      const fwConstants = getFwVersionConst(client.fwVersion);
+      const GAS_PRICE_MAX = fwConstants.ethMaxGasPrice;
+      const GAS_LIMIT_MIN = 22000;
+      const GAS_LIMIT_MAX = 12500000;
+
+      const txData = {
+        nonce: '0x02',
+        gasPrice: '0x1fe5d61a00',
+        gasLimit: '0x034e97',
+        to: '0x1af768c0a217804cfe1a0fb739230b546a566cd6',
+        value: '0x01cba1761f7ab9870c',
+        data: '0x17e914679b7e160613be4f8c2d3203d236286d74eb9192f6d6f71b9118a42bb033ccd8e8',
+      };
+      const req: any = {
+        currency: 'ETH',
+        data: {
+          signerPath: [
+            helpers.BTC_PURPOSE_P2PKH,
+            helpers.ETH_COIN,
+            HARDENED_OFFSET,
+            0,
+            0,
+          ],
+          ...txData,
+          chainId: 'rinkeby', // Can also be an integer
+        },
+      };
+      // Sign a tx that does not use EIP155 (no EIP155 on rinkeby for some reason)
+      let tx;
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
-    req.data.chainId = 'rinkeby';
+      expect(tx.tx).to.not.equal(null);
 
-    // Nonce too large (>u16)
-    req.data.nonce = 0xffff + 1;
-    try {
+      // Sign a tx with EIP155
+      req.data.chainId = 'mainnet';
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
-    // Reset to valid param
-    req.data.nonce = 5;
+      expect(tx.tx).to.not.equal(null);
+      req.data.chainId = 'rinkeby';
 
-    // GasLimit too low
-    req.data.gasLimit = GAS_LIMIT_MIN - 1;
-    try {
+      req.data.data = client.crypto
+        .randomBytes(fwConstants.ethMaxDataSz)
+        .toString('hex');
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
+      expect(tx.tx).to.not.equal(null);
+      req.data.data = null;
 
-    // GasLimit too high (>u32)
-    req.data.gasLimit = GAS_LIMIT_MAX + 1;
-    try {
+      // Invalid chainId
+      req.data.chainId = 'notachain';
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      req.data.chainId = 'rinkeby';
+
+      // Nonce too large (>u16)
+      req.data.nonce = 0xffff + 1;
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      // Reset to valid param
+      req.data.nonce = 5;
+
+      // GasLimit too low
+      req.data.gasLimit = GAS_LIMIT_MIN - 1;
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+
+      // GasLimit too high (>u32)
+      req.data.gasLimit = GAS_LIMIT_MAX + 1;
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      // Reset to valid param
+      req.data.gasLimit = 122000;
+
+      // GasPrice too high
+      req.data.gasPrice = GAS_PRICE_MAX + 1;
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      // Reset to valid param
+      req.data.gasPrice = 1200000000;
+
+      // `to` wrong size
+      req.data.to = '0xe242e54155b1abc71fc118065270cecaaf8b77';
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      // Reset to valid param
+      req.data.to = '0xe242e54155b1abc71fc118065270cecaaf8b7768';
+
+      // Value too high
+      req.data.value = 2 ** 256;
+      try {
+        tx = await helpers.execute(client, 'sign', req);
+        expect(tx.tx).to.equal(null);
+      } catch (err) {
+        expect(err).to.not.equal(null);
+      }
+      // Reset to valid param
+      req.data.value = 0.3 * 10 ** 18;
+
+      // Test data range
+      const maxDataSz =
+        fwConstants.ethMaxDataSz +
+        fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
+      req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
-    // Reset to valid param
-    req.data.gasLimit = 122000;
-
-    // GasPrice too high
-    req.data.gasPrice = GAS_PRICE_MAX + 1;
-    try {
+      expect(tx.tx).to.not.equal(null);
+      question(
+        'Please ACCEPT the following transaction only if the warning screen displays. Press enter to continue.'
+      );
+      req.data.data = client.crypto.randomBytes(maxDataSz + 1).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
-    // Reset to valid param
-    req.data.gasPrice = 1200000000;
-
-    // `to` wrong size
-    req.data.to = '0xe242e54155b1abc71fc118065270cecaaf8b77';
-    try {
+      expect(tx.tx).to.not.equal(null);
+      req.data.data = client.crypto
+        .randomBytes(fwConstants.ethMaxDataSz)
+        .toString('hex');
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
-    } catch (err) {
-      expect(err).to.not.equal(null);
-    }
-    // Reset to valid param
-    req.data.to = '0xe242e54155b1abc71fc118065270cecaaf8b7768';
-
-    // Value too high
-    req.data.value = 2 ** 256;
-    try {
+      expect(tx.tx).to.not.equal(null);
+      req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
-      expect(tx.tx).to.equal(null);
+      expect(tx.tx).to.not.equal(null);
+
+      // Test non-ETH EVM coin_type
+      req.data.signerPath[1] = HARDENED_OFFSET + 1007;
+      req.data.data = null;
+      tx = await helpers.execute(client, 'sign', req);
+      expect(tx.tx).to.not.equal(null);
+      continueTests = true;
     } catch (err) {
-      expect(err).to.not.equal(null);
+      expect(err).to.equal(null, err);
     }
-    // Reset to valid param
-    req.data.value = 0.3 * 10 ** 18;
-
-    // Test data range
-    const maxDataSz =
-      fwConstants.ethMaxDataSz +
-      fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
-    req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-    question(
-      'Please ACCEPT the following transaction only if the warning screen displays. Press enter to continue.'
-    );
-    req.data.data = client.crypto.randomBytes(maxDataSz + 1).toString('hex');
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-    req.data.data = client.crypto
-      .randomBytes(fwConstants.ethMaxDataSz)
-      .toString('hex');
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-    req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
-
-    // Test non-ETH EVM coin_type
-    req.data.signerPath[1] = HARDENED_OFFSET + 1007;
-    req.data.data = null;
-    tx = await helpers.execute(client, 'sign', req);
-    expect(tx.tx).to.not.equal(null);
   });
 
   it('Should sign legacy Bitcoin inputs', async () => {
-    const txData = {
-      prevOuts: [
-        {
-          txHash:
-            '6e78493091f80d89a92ae3152df7fbfbdc44df09cf01a9b76c5113c02eaf2e0f',
-          value: 10000,
-          index: 1,
-          signerPath: [
-            helpers.BTC_PURPOSE_P2SH_P2WPKH,
-            helpers.BTC_TESTNET_COIN,
-            HARDENED_OFFSET,
-            0,
-            0,
-          ],
-        },
-      ],
-      recipient: 'mhifA1DwiMPHTjSJM8FFSL8ibrzWaBCkVT',
-      value: 1000,
-      fee: 1000,
-      // isSegwit: false, // old encoding
-      changePath: [
-        helpers.BTC_PURPOSE_P2SH_P2WPKH,
-        helpers.BTC_TESTNET_COIN,
-        HARDENED_OFFSET,
-        1,
-        0,
-      ],
-    };
-    const req = {
-      currency: 'BTC',
-      data: txData,
-    };
+    try {
+      continueTests = false;
+      const txData = {
+        prevOuts: [
+          {
+            txHash:
+              '6e78493091f80d89a92ae3152df7fbfbdc44df09cf01a9b76c5113c02eaf2e0f',
+            value: 10000,
+            index: 1,
+            signerPath: [
+              helpers.BTC_PURPOSE_P2SH_P2WPKH,
+              helpers.BTC_TESTNET_COIN,
+              HARDENED_OFFSET,
+              0,
+              0,
+            ],
+          },
+        ],
+        recipient: 'mhifA1DwiMPHTjSJM8FFSL8ibrzWaBCkVT',
+        value: 1000,
+        fee: 1000,
+        // isSegwit: false, // old encoding
+        changePath: [
+          helpers.BTC_PURPOSE_P2SH_P2WPKH,
+          helpers.BTC_TESTNET_COIN,
+          HARDENED_OFFSET,
+          1,
+          0,
+        ],
+      };
+      const req = {
+        currency: 'BTC',
+        data: txData,
+      };
 
-    // Sign a legit tx
-    const sigResp: any = await helpers.execute(client, 'sign', req);
-    expect(sigResp.tx).to.not.equal(null);
-    expect(sigResp.txHash).to.not.equal(null);
+      // Sign a legit tx
+      const sigResp = await helpers.execute(client, 'sign', req);
+      expect(sigResp.tx).to.not.equal(null);
+      expect(sigResp.txHash).to.not.equal(null);
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
+    }
   });
 
   it('Should sign wrapped segwit Bitcoin inputs', async () => {
-    const txData = {
-      prevOuts: [
-        {
-          txHash:
-            'ab8288ef207f11186af98db115aa7120aa36ceb783e8792fb7b2f39c88109a99',
-          value: 10000,
-          index: 1,
-          signerPath: [
-            helpers.BTC_PURPOSE_P2SH_P2WPKH,
-            helpers.BTC_TESTNET_COIN,
-            HARDENED_OFFSET,
-            0,
-            0,
-          ],
-        },
-      ],
-      recipient: '2NGZrVvZG92qGYqzTLjCAewvPZ7JE8S8VxE',
-      value: 1000,
-      fee: 1000,
-      changePath: [
-        helpers.BTC_PURPOSE_P2SH_P2WPKH,
-        helpers.BTC_TESTNET_COIN,
-        HARDENED_OFFSET,
-        1,
-        0,
-      ],
-    };
-    const req = {
-      currency: 'BTC',
-      data: txData,
-    };
-    // Sign a legit tx
-    const sigResp: any = await helpers.execute(client, 'sign', req);
-    expect(sigResp.tx).to.not.equal(null);
-    expect(sigResp.txHash).to.not.equal(null);
+    try {
+      continueTests = false;
+      const txData = {
+        prevOuts: [
+          {
+            txHash:
+              'ab8288ef207f11186af98db115aa7120aa36ceb783e8792fb7b2f39c88109a99',
+            value: 10000,
+            index: 1,
+            signerPath: [
+              helpers.BTC_PURPOSE_P2SH_P2WPKH,
+              helpers.BTC_TESTNET_COIN,
+              HARDENED_OFFSET,
+              0,
+              0,
+            ],
+          },
+        ],
+        recipient: '2NGZrVvZG92qGYqzTLjCAewvPZ7JE8S8VxE',
+        value: 1000,
+        fee: 1000,
+        changePath: [
+          helpers.BTC_PURPOSE_P2SH_P2WPKH,
+          helpers.BTC_TESTNET_COIN,
+          HARDENED_OFFSET,
+          1,
+          0,
+        ],
+      };
+      const req = {
+        currency: 'BTC',
+        data: txData,
+      };
+      // Sign a legit tx
+      const sigResp = await helpers.execute(client, 'sign', req);
+      expect(sigResp.tx).to.not.equal(null);
+      expect(sigResp.txHash).to.not.equal(null);
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
+    }
   });
 
   it('Should sign wrapped segwit Bitcoin inputs to a bech32 address', async () => {
-    const txData = {
-      prevOuts: [
-        {
-          txHash:
-            'f93d0a77f58b4274d84f427d647f1f27e38b4db79fd975691e15109fde7ea06e',
-          value: 1802440,
-          index: 1,
-          signerPath: [
-            helpers.BTC_PURPOSE_P2SH_P2WPKH,
-            helpers.BTC_TESTNET_COIN,
-            HARDENED_OFFSET,
-            1,
-            0,
-          ],
-        },
-      ],
-      recipient: 'tb1qym0z2a939lefrgw67ep5flhf43dvpg3h4s96tn',
-      value: 1000,
-      fee: 1000,
-      changePath: [
-        helpers.BTC_PURPOSE_P2SH_P2WPKH,
-        helpers.BTC_TESTNET_COIN,
-        HARDENED_OFFSET,
-        1,
-        0,
-      ],
-    };
-    const req = {
-      currency: 'BTC',
-      data: txData,
-    };
-    // Sign a legit tx
-    const sigResp: any = await helpers.execute(client, 'sign', req);
-    expect(sigResp.tx).to.not.equal(null);
-    expect(sigResp.txHash).to.not.equal(null);
+    try {
+      continueTests = false;
+      const txData = {
+        prevOuts: [
+          {
+            txHash:
+              'f93d0a77f58b4274d84f427d647f1f27e38b4db79fd975691e15109fde7ea06e',
+            value: 1802440,
+            index: 1,
+            signerPath: [
+              helpers.BTC_PURPOSE_P2SH_P2WPKH,
+              helpers.BTC_TESTNET_COIN,
+              HARDENED_OFFSET,
+              1,
+              0,
+            ],
+          },
+        ],
+        recipient: 'tb1qym0z2a939lefrgw67ep5flhf43dvpg3h4s96tn',
+        value: 1000,
+        fee: 1000,
+        changePath: [
+          helpers.BTC_PURPOSE_P2SH_P2WPKH,
+          helpers.BTC_TESTNET_COIN,
+          HARDENED_OFFSET,
+          1,
+          0,
+        ],
+      };
+      const req = {
+        currency: 'BTC',
+        data: txData,
+      };
+      // Sign a legit tx
+      const sigResp = await helpers.execute(client, 'sign', req);
+      expect(sigResp.tx).to.not.equal(null);
+      expect(sigResp.txHash).to.not.equal(null);
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
+    }
   });
 
   it('Should sign an input from a native segwit account', async () => {
-    const txData = {
-      prevOuts: [
-        {
-          txHash:
-            'b2efdbdd3340d2bc547671ce3993a6f05d70343c07578f9d7f5626fdfc06fa35',
-          value: 76800,
-          index: 0,
+    try {
+      continueTests = false;
+      const txData = {
+        prevOuts: [
+          {
+            txHash:
+              'b2efdbdd3340d2bc547671ce3993a6f05d70343c07578f9d7f5626fdfc06fa35',
+            value: 76800,
+            index: 0,
+            signerPath: [
+              helpers.BTC_PURPOSE_P2WPKH,
+              helpers.BTC_TESTNET_COIN,
+              HARDENED_OFFSET,
+              0,
+              0,
+            ],
+          },
+        ],
+        recipient: '2N4gqWT4oqWL2gz9ps92z9fm2Bg3FUkqG7Q',
+        value: 70000,
+        fee: 4380,
+        isSegwit: true,
+        changePath: [
+          helpers.BTC_PURPOSE_P2WPKH,
+          helpers.BTC_TESTNET_COIN,
+          HARDENED_OFFSET,
+          1,
+          0,
+        ],
+      };
+      const req = {
+        currency: 'BTC',
+        data: txData,
+      };
+      // Sign a legit tx
+      const sigResp = await helpers.execute(client, 'sign', req);
+      expect(sigResp.tx).to.not.equal(null);
+      expect(sigResp.txHash).to.not.equal(null);
+      expect(sigResp.changeRecipient.slice(0, 2)).to.equal('tb');
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
+    }
+  });
+
+  it('Should test permission limits', async () => {
+    try {
+      continueTests = false;
+      // Fail to add permissions where limit or window is 0
+      const opts = {
+        currency: 'ETH',
+        timeWindow: 0,
+        limit: 5,
+        decimals: 18,
+        asset: null,
+      };
+      try {
+        await helpers.execute(client, 'addPermissionV0', opts);
+      } catch (err) {
+        expect(err).to.equal('Time window and spending limit must be positive.');
+      }
+      try {
+        opts.timeWindow = 300;
+        opts.limit = 0;
+        await helpers.execute(client, 'addPermissionV0', opts);
+      } catch (err) {
+        expect(err).to.equal('Time window and spending limit must be positive.');
+      }
+      // Add a 5-minute permission allowing 5 wei to be spent
+      opts.timeWindow = 300;
+      opts.limit = 5;
+      await helpers.execute(client, 'addPermissionV0', opts);
+      // Fail to add the same permission again
+      try {
+        await helpers.execute(client, 'addPermissionV0', opts);
+      } catch (err) {
+        const expectedCode = responseCodes.RESP_ERR_ALREADY;
+        expect(
+          err.indexOf(responseMsgs[expectedCode])
+        ).to.be.greaterThan(-1);
+      }
+      // Spend 2 wei
+      const txData = {
+        nonce: 0,
+        gasPrice: 1200000000,
+        gasLimit: 50000,
+        to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
+        value: 2,
+        data: null,
+      };
+      const req = {
+        currency: 'ETH',
+        data: {
           signerPath: [
-            helpers.BTC_PURPOSE_P2WPKH,
-            helpers.BTC_TESTNET_COIN,
+            helpers.BTC_PURPOSE_P2PKH,
+            helpers.ETH_COIN,
             HARDENED_OFFSET,
             0,
             0,
           ],
+          ...txData,
+          chainId: 'rinkeby', // Can also be an integer
         },
-      ],
-      recipient: '2N4gqWT4oqWL2gz9ps92z9fm2Bg3FUkqG7Q',
-      value: 70000,
-      fee: 4380,
-      isSegwit: true,
-      changePath: [
-        helpers.BTC_PURPOSE_P2WPKH,
-        helpers.BTC_TESTNET_COIN,
-        HARDENED_OFFSET,
-        1,
-        0,
-      ],
-    };
-    const req = {
-      currency: 'BTC',
-      data: txData,
-    };
-    // Sign a legit tx
-    const sigResp: any = await helpers.execute(client, 'sign', req);
-    expect(sigResp.tx).to.not.equal(null);
-    expect(sigResp.txHash).to.not.equal(null);
-    expect(sigResp.changeRecipient.slice(0, 2)).to.equal('tb');
-  });
-
-  it('Should test permission limits', async () => {
-    // Fail to add permissions where limit or window is 0
-    const opts = {
-      currency: 'ETH',
-      timeWindow: 0,
-      limit: 5,
-      decimals: 18,
-      asset: null,
-    };
-    try {
-      await helpers.execute(client, 'addPermissionV0', opts);
-    } catch (err) {
-      expect(err).to.equal('Time window and spending limit must be positive.');
-    }
-    try {
-      opts.timeWindow = 300;
-      opts.limit = 0;
-      await helpers.execute(client, 'addPermissionV0', opts);
-    } catch (err) {
-      expect(err).to.equal('Time window and spending limit must be positive.');
-    }
-    // Add a 5-minute permission allowing 5 wei to be spent
-    opts.timeWindow = 300;
-    opts.limit = 5;
-    await helpers.execute(client, 'addPermissionV0', opts);
-    // Fail to add the same permission again
-    try {
-      await helpers.execute(client, 'addPermissionV0', opts);
-    } catch (err) {
-      const expectedCode = responseCodes.RESP_ERR_ALREADY;
-      expect(
-        err.indexOf(responseMsgs[expectedCode])
-      ).to.be.greaterThan(-1);
-    }
-    // Spend 2 wei
-    const txData = {
-      nonce: 0,
-      gasPrice: 1200000000,
-      gasLimit: 50000,
-      to: '0xe242e54155b1abc71fc118065270cecaaf8b7768',
-      value: 2,
-      data: null,
-    };
-    const req = {
-      currency: 'ETH',
-      data: {
-        signerPath: [
-          helpers.BTC_PURPOSE_P2PKH,
-          helpers.ETH_COIN,
-          HARDENED_OFFSET,
-          0,
-          0,
-        ],
-        ...txData,
-        chainId: 'rinkeby', // Can also be an integer
-      },
-    };
-    // Test the spending limit. The first two requests should auto-sign.
-    // Spend once -> 3 wei left
-    let signResp: any = await helpers.execute(client, 'sign', req);
-    expect(signResp.tx).to.not.equal(null);
-    // Spend again -> 1 wei left
-    signResp = await helpers.execute(client, 'sign', req);
-    expect(signResp.tx).to.not.equal(null);
-    // Spend again. This time it should fail to load the permission
-    question(
-      'Please REJECT the following transaction request. Press enter to continue.'
-    );
-    try {
+      };
+      // Test the spending limit. The first two requests should auto-sign.
+      // Spend once -> 3 wei left
+      let signResp = await helpers.execute(client, 'sign', req);
+      expect(signResp.tx).to.not.equal(null);
+      // Spend again -> 1 wei left
       signResp = await helpers.execute(client, 'sign', req);
-      expect(signResp.tx).to.equal(null);
+      expect(signResp.tx).to.not.equal(null);
+      // Spend again. This time it should fail to load the permission
+      question(
+        'Please REJECT the following transaction request. Press enter to continue.'
+      );
+      try {
+        signResp = await helpers.execute(client, 'sign', req);
+        expect(signResp.tx).to.equal(null);
+      } catch (err) {
+        const expectedCode = responseCodes.RESP_ERR_USER_DECLINED;
+        expect(
+          err.indexOf(responseMsgs[expectedCode])
+        ).to.be.greaterThan(-1);
+      }
+      // Spend 1 wei this time. This should be allowed by the permission.
+      req.data.value = 1;
+      signResp = await helpers.execute(client, 'sign', req);
+      expect(signResp.tx).to.not.equal(null);
+      continueTests = true;
     } catch (err) {
-      const expectedCode = responseCodes.RESP_ERR_USER_DECLINED;
-      expect(
-        err.indexOf(responseMsgs[expectedCode])
-      ).to.be.greaterThan(-1);
+      expect(err).to.equal(null, err);
     }
-    // Spend 1 wei this time. This should be allowed by the permission.
-    req.data.value = 1;
-    signResp = await helpers.execute(client, 'sign', req);
-    expect(signResp.tx).to.not.equal(null);
   });
 });

--- a/test/testBtc.ts
+++ b/test/testBtc.ts
@@ -1,5 +1,4 @@
 // You must have `FEATURE_TEST_RUNNER=0` enabled in firmware to run these tests.
-require('it-each')({ testPerIteration: true });
 import bip32 from 'bip32';
 import { expect } from 'chai';
 import seedrandom from 'seedrandom';
@@ -18,7 +17,6 @@ function rand32Bit() {
   return Math.floor(prng.quick() * 2 ** 32);
 }
 const inputs = [];
-const numInputs = [];
 const count = process.env.N ? process.env.N : 3;
 for (let i = 0; i < count; i++) {
   const hash = Buffer.alloc(32);
@@ -30,11 +28,10 @@ for (let i = 0; i < count; i++) {
   const signerIdx = Math.floor(prng.quick() * 19); // Random signer (keep it inside initial cache of 20)
   const idx = Math.floor(prng.quick() * 25); // Random previous output index (keep it small)
   inputs.push({ hash: hash.toString('hex'), value, signerIdx, idx });
-  numInputs.push({ label: `${i + 1}`, number: i + 1 });
 }
 
 async function testSign(req, signingKeys, sigHashes) {
-  const tx: any = await helpers.execute(client, 'sign', req);
+  const tx = await helpers.execute(client, 'sign', req);
   expect(tx.sigs.length).to.equal(signingKeys.length);
   expect(tx.sigs.length).to.equal(sigHashes.length);
   for (let i = 0; i < tx.sigs.length; i++) {
@@ -154,151 +151,178 @@ describe('Test segwit spender (p2wpkh)', function () {
   beforeEach(() => {
     expect(continueTests).to.equal(true, 'Previous test failed. Aborting');
   });
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2wpkh->p2pkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+
+  it('Should test p2wpkh->p2pkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2wpkh->p2sh-p2wpkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+  })
+
+  it('Should test p2wpkh->p2sh-p2wpkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2wpkh->p2wpkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+  })
+
+  it('Should test p2wpkh->p2wpkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-});
+  })
+})
 
 describe('Test wrapped segwit spender (p2sh-p2wpkh)', function () {
   beforeEach(() => {
     expect(continueTests).to.equal(true, 'Previous test failed. Aborting');
   });
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2sh-p2wpkh->p2pkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+
+  it('Should test p2sh-p2wpkh->p2pkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2sh-p2wpkh->p2sh-p2wpkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+  })
+
+  it('Should test p2sh-p2wpkh->p2sh-p2wpkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2sh-p2wpkh->p2wpkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+  })
+
+  it('Should test p2sh-p2wpkh->p2wpkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-});
+  })
+})
 
 describe('Test legacy spender (p2pkh)', function () {
   beforeEach(() => {
     expect(continueTests).to.equal(true, 'Previous test failed. Aborting');
   });
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2pkh->p2pkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+
+  it('Should test p2pkh->p2pkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2pkh->p2sh-p2wpkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+  })
+
+  it('Should test p2pkh->p2sh-p2wpkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    numInputs,
-    '%s inputs (p2pkh->p2wpkh)',
-    ['label'],
-    async function (n, next) {
-      expect(wallet).to.not.equal(null, 'Wallet not available');
-      const inputsSlice = inputs.slice(0, n.number);
-      const opts = {
-        spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
-        recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
-      };
-      await runTestSet(opts, wallet, inputsSlice, next);
+  })
+
+  it('Should test p2pkh->p2wpkh', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < inputs.length; i++) {
+        expect(wallet).to.not.equal(null, 'Wallet not available');
+        const inputsSlice = inputs.slice(0, i + 1);
+        const opts = {
+          spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
+          recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
+        };
+        await runTestSet(opts, wallet, inputsSlice, next);
+        continueTests = true;
+      }
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-});
+  })
+})

--- a/test/testBtc.ts
+++ b/test/testBtc.ts
@@ -81,7 +81,7 @@ async function run(p) {
   await testSign(p.txReq, p.signingKeys, p.sigHashes);
 }
 
-async function runTestSet(opts, wallet, inputsSlice, next) {
+async function runTestSet(opts, wallet, inputsSlice) {
   if (TEST_TESTNET) {
     // Testnet + change
     try {
@@ -96,7 +96,6 @@ async function runTestSet(opts, wallet, inputsSlice, next) {
         `Failed in (testnet, change): ${err.message()}`
       );
       continueTests = false;
-      next(err);
     }
     // Testnet + no change
     try {
@@ -111,7 +110,6 @@ async function runTestSet(opts, wallet, inputsSlice, next) {
         `Failed in (testnet, !change): ${err.message()}`
       );
       continueTests = false;
-      next(err);
     }
   }
   // Mainnet + change
@@ -127,7 +125,6 @@ async function runTestSet(opts, wallet, inputsSlice, next) {
       `Failed in (!testnet, change): ${err.message()}`
     );
     continueTests = false;
-    next(err);
   }
   // Mainnet + no change
   try {
@@ -142,9 +139,7 @@ async function runTestSet(opts, wallet, inputsSlice, next) {
       `Failed in (!testnet, !change): ${err.message()}`
     );
     continueTests = false;
-    next(err);
   }
-  next();
 }
 
 describe('Test segwit spender (p2wpkh)', function () {
@@ -162,7 +157,7 @@ describe('Test segwit spender (p2wpkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -180,7 +175,7 @@ describe('Test segwit spender (p2wpkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -198,7 +193,7 @@ describe('Test segwit spender (p2wpkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2WPKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -222,7 +217,7 @@ describe('Test wrapped segwit spender (p2sh-p2wpkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -240,7 +235,7 @@ describe('Test wrapped segwit spender (p2sh-p2wpkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -258,7 +253,7 @@ describe('Test wrapped segwit spender (p2sh-p2wpkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -282,7 +277,7 @@ describe('Test legacy spender (p2pkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2PKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -300,7 +295,7 @@ describe('Test legacy spender (p2pkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2SH_P2WPKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {
@@ -318,7 +313,7 @@ describe('Test legacy spender (p2pkh)', function () {
           spenderPurpose: helpers.BTC_PURPOSE_P2PKH,
           recipientPurpose: helpers.BTC_PURPOSE_P2WPKH,
         };
-        await runTestSet(opts, wallet, inputsSlice, next);
+        await runTestSet(opts, wallet, inputsSlice);
         continueTests = true;
       }
     } catch (err) {

--- a/test/testEthMsg.ts
+++ b/test/testEthMsg.ts
@@ -14,7 +14,6 @@
 //
 // NOTE: It is highly suggested that you set `AUTO_SIGN_DEV_ONLY=1` in the firmware
 //        root CMakeLists.txt file (for dev units)
-require('it-each')({ testPerIteration: true });
 import { expect } from 'chai';
 import crypto from 'crypto';
 import randomWords from 'random-words';
@@ -25,7 +24,6 @@ const prng = new seedrandom(process.env.SEED || 'myrandomseed');
 let client = null;
 let numRandom = 20; // Number of random tests to conduct
 const MSG_PAYLOAD_METADATA_SZ = 28; // Metadata that must go in ETH_MSG requests
-let ETH_GAS_PRICE_MAX: any; // value depends on firmware version
 let foundError = false;
 
 function randInt(n) {

--- a/test/testSigs.ts
+++ b/test/testSigs.ts
@@ -1,5 +1,4 @@
 // You must have `FEATURE_TEST_RUNNER=1` enabled in firmware to run these tests.
-require('it-each')({ testPerIteration: true });
 import bip32 from 'bip32';
 import { mnemonicToSeedSync } from 'bip39';
 import { expect } from 'chai';
@@ -39,17 +38,15 @@ const PRNG = new seedrandom(process.env.SEED || 'myrandomseed');
 
 // Generate a bunch of random test vectors using the PRNG
 const RANDOM_VEC = [];
-const RANDOM_VEC_LABELS = [];
 for (let i = 0; i < numIter; i++) {
   RANDOM_VEC.push(Math.floor(1000000000 * PRNG.quick()).toString(16));
-  RANDOM_VEC_LABELS.push({ label: `${i + 1}/${numIter}`, number: i });
 }
 
 //---------
 // Helpers
 //---------
 async function runTestCase(expectedCode) {
-  const res: any = await helpers.execute(client, 'test', jobReq);
+  const res = await helpers.execute(client, 'test', jobReq);
   const parsedRes = helpers.parseWalletJobResp(res, client.fwVersion);
   if (parsedRes.resultStatus !== expectedCode) {
     continueTests = false;
@@ -68,7 +65,7 @@ function signPersonalJS(_msg, path) {
   const wallet = bip32.fromSeed(TEST_SEED);
   const priv = wallet.derivePath(helpers.getPathStr(path)).privateKey;
   const msg = helpers.ethPersonalSignMsg(_msg);
-  const hash: any = new Uint8Array(Buffer.from(keccak256(msg), 'hex'));
+  const hash = new Uint8Array(Buffer.from(keccak256(msg), 'hex'));
   const sig = ecsign(hash, priv);
   const v = (sig.v - 27).toString(16).padStart(2, '0');
   return `${sig.r.toString('hex')}${sig.s.toString('hex')}${v}`;
@@ -81,7 +78,7 @@ function getSigStr(sig) {
   return `${sig.r}${sig.s}${v}`;
 }
 
-function _setupJob (type, opts: any = {}) {
+function _setupJob (type, opts = {}) {
   if (type === helpers.jobTypes.WALLET_JOB_EXPORT_SEED) {
     jobType = type;
     jobData = {};
@@ -135,7 +132,7 @@ describe('Connect', () => {
   before(() => {
     // Setup the SDK client
     client = helpers.setupTestClient(process.env);
-  });
+  })
 
   it('Should connect to a Lattice and make sure it is already paired.', async () => {
     expect(process.env.DEVICE_ID).to.not.equal(null);
@@ -143,8 +140,8 @@ describe('Connect', () => {
     expect(client.isPaired).to.equal(true);
     expect(client.hasActiveWallet()).to.equal(true);
     activeWalletUID = helpers.copyBuffer(client.getActiveWallet().uid);
-  });
-});
+  })
+})
 
 describe('Test non-exportable seed on SafeCard (if available)', () => {
   beforeEach(() => {
@@ -152,7 +149,8 @@ describe('Test non-exportable seed on SafeCard (if available)', () => {
       true,
       'Unauthorized or critical failure. Aborting'
     );
-  });
+  })
+
   // This needs to be done before tests that use the `test` API route because
   // there is some sort of bug related to directly submitting wallet jobs
   // and then switching EMV interfaces.
@@ -168,7 +166,8 @@ describe('Test non-exportable seed on SafeCard (if available)', () => {
     if (result.toLowerCase() !== 'y') {
       skipNonExportableSeed = true;
     }
-  });
+  })
+
   it('Should validate non-exportable seed sigs all differ and validate', async () => {
     if (skipNonExportableSeed) {
       return;
@@ -190,7 +189,7 @@ describe('Test non-exportable seed on SafeCard (if available)', () => {
     };
     // Validate that tx sigs are non-uniform
     txReq.data.signerPath[2] = HARDENED_OFFSET;
-    let tx1_addr0: any, tx2_addr0: any, tx3_addr0: any, tx4_addr0: any, tx5_addr0: any;
+    let tx1_addr0, tx2_addr0, tx3_addr0, tx4_addr0, tx5_addr0;
     try {
       tx1_addr0 = await helpers.execute(client, 'sign', txReq);
       tx2_addr0 = await helpers.execute(client, 'sign', txReq);
@@ -270,7 +269,7 @@ describe('Test non-exportable seed on SafeCard (if available)', () => {
     );
     process.exit(1);
   })
-});
+})
 
 describe('Setup Test', () => {
   beforeEach(() => {
@@ -286,7 +285,7 @@ describe('Setup Test', () => {
       true,
       'Unauthorized or critical failure. Aborting'
     );
-  });
+  })
 
   it('Should find out if we need to load the seed', async () => {
     // Determine if we should skip the process of loading the test seed.
@@ -299,7 +298,7 @@ describe('Setup Test', () => {
     if (result.toLowerCase() !== 'n') {
       skipSeedLoading = true;
     }
-  });
+  })
 
   it('Should fetch the seed', async () => {
     if (skipSeedLoading) return;
@@ -307,19 +306,19 @@ describe('Setup Test', () => {
     const _res = await runTestCase(helpers.gpErrors.GP_SUCCESS);
     const res = helpers.deserializeExportSeedJobResult(_res.result);
     latticeSeed = helpers.copyBuffer(res.seed);
-  });
+  })
 
   it('Should remove the seed', async () => {
     if (skipSeedLoading) return;
     _setupJob(helpers.jobTypes.WALLET_JOB_DELETE_SEED);
     await runTestCase(helpers.gpErrors.GP_SUCCESS);
-  });
+  })
 
   it('Should load the known test seed', async () => {
     if (skipSeedLoading) return;
     _setupJob(helpers.jobTypes.WALLET_JOB_LOAD_SEED, { seed: TEST_SEED });
     await runTestCase(helpers.gpErrors.GP_SUCCESS);
-  });
+  })
 
   it('Should wait for the user to remove and re-insert the card (triggering SafeCard wallet sync)', () => {
     if (skipSeedLoading) return;
@@ -327,7 +326,7 @@ describe('Setup Test', () => {
       '\nPlease remove, re-insert, and unlock your SafeCard.\n' +
         'Press enter to continue after addresses have fully synced.'
     );
-  });
+  })
 
   it('Should re-connect to the Lattice and update the walletUID.', async () => {
     expect(process.env.DEVICE_ID).to.not.equal(null);
@@ -335,7 +334,7 @@ describe('Setup Test', () => {
     expect(client.isPaired).to.equal(true);
     expect(client.hasActiveWallet()).to.equal(true);
     activeWalletUID = helpers.copyBuffer(client.getActiveWallet().uid);
-  });
+  })
 
   it('Should ensure export seed matches the test seed', async () => {
     _setupJob(helpers.jobTypes.WALLET_JOB_EXPORT_SEED);
@@ -349,7 +348,7 @@ describe('Setup Test', () => {
     // Abort if this fails
     if (exportedSeed.toString('hex') !== TEST_SEED.toString('hex'))
       continueTests = false;
-  });
+  })
 
   it('Should validate some Ledger addresses derived from the test seed', async () => {
     // These addresses were all fetched using MetaMask with a real ledger loaded with TEST_MNEOMNIC
@@ -415,8 +414,8 @@ describe('Setup Test', () => {
       addr8.toLowerCase(),
       'Incorrect address 8 fetched.'
     );
-  });
-});
+  })
+})
 
 describe('Test uniformity of Ethereum transaction sigs', () => {
   beforeEach(() => {
@@ -439,16 +438,16 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
         data: '0xdeadbeef',
       },
     };
-  });
+  })
 
   it('Should validate uniformity of 5 consecutive tx signatures', async () => {
     try {
       txReq.data.signerPath[2] = HARDENED_OFFSET;
-      const tx1_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx2_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx3_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx4_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx5_addr0: any = await helpers.execute(client, 'sign', txReq);
+      const tx1_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx2_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx3_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx4_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx5_addr0 = await helpers.execute(client, 'sign', txReq);
       expect(getSigStr(tx1_addr0.sig)).to.equal(
         getSigStr(tx2_addr0.sig),
         'Txs not uniform:'
@@ -466,11 +465,11 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
         'Txs not uniform:'
       );
       txReq.data.signerPath[2] = HARDENED_OFFSET + 1;
-      const tx1_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx2_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx3_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx4_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx5_addr1: any = await helpers.execute(client, 'sign', txReq);
+      const tx1_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx2_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx3_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx4_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx5_addr1 = await helpers.execute(client, 'sign', txReq);
       expect(getSigStr(tx1_addr1.sig)).to.equal(
         getSigStr(tx2_addr1.sig),
         'Txs not uniform:'
@@ -488,11 +487,11 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
         'Txs not uniform:'
       );
       txReq.data.signerPath[2] = HARDENED_OFFSET + 8;
-      const tx1_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx2_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx3_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx4_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx5_addr8: any = await helpers.execute(client, 'sign', txReq);
+      const tx1_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx2_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx3_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx4_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx5_addr8 = await helpers.execute(client, 'sign', txReq);
       expect(getSigStr(tx1_addr8.sig)).to.equal(
         getSigStr(tx2_addr8.sig),
         'Txs not uniform:'
@@ -511,17 +510,17 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
     } catch (err) {
       expect(err.message).to.equal(null, 'Caught error: ');
     }
-  });
+  })
 
   it('Should validate uniformity of 5 consecutive tx signatures (with oversized data)', async () => {
     try {
       txReq.data.data = `0x${crypto.randomBytes(4000).toString('hex')}`;
       txReq.data.signerPath[2] = HARDENED_OFFSET;
-      const tx1_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx2_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx3_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx4_addr0: any = await helpers.execute(client, 'sign', txReq);
-      const tx5_addr0: any = await helpers.execute(client, 'sign', txReq);
+      const tx1_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx2_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx3_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx4_addr0 = await helpers.execute(client, 'sign', txReq);
+      const tx5_addr0 = await helpers.execute(client, 'sign', txReq);
       expect(getSigStr(tx1_addr0.sig)).to.equal(
         getSigStr(tx2_addr0.sig),
         'Txs not uniform:'
@@ -539,11 +538,11 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
         'Txs not uniform:'
       );
       txReq.data.signerPath[2] = HARDENED_OFFSET + 1;
-      const tx1_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx2_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx3_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx4_addr1: any = await helpers.execute(client, 'sign', txReq);
-      const tx5_addr1: any = await helpers.execute(client, 'sign', txReq);
+      const tx1_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx2_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx3_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx4_addr1 = await helpers.execute(client, 'sign', txReq);
+      const tx5_addr1 = await helpers.execute(client, 'sign', txReq);
       expect(getSigStr(tx1_addr1.sig)).to.equal(
         getSigStr(tx2_addr1.sig),
         'Txs not uniform:'
@@ -561,11 +560,11 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
         'Txs not uniform:'
       );
       txReq.data.signerPath[2] = HARDENED_OFFSET + 8;
-      const tx1_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx2_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx3_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx4_addr8: any = await helpers.execute(client, 'sign', txReq);
-      const tx5_addr8: any = await helpers.execute(client, 'sign', txReq);
+      const tx1_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx2_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx3_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx4_addr8 = await helpers.execute(client, 'sign', txReq);
+      const tx5_addr8 = await helpers.execute(client, 'sign', txReq);
       expect(getSigStr(tx1_addr8.sig)).to.equal(
         getSigStr(tx2_addr8.sig),
         'Txs not uniform:'
@@ -585,8 +584,8 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
     } catch (err) {
       expect(err.message).to.equal(null, 'Caught error: ');
     }
-  });
-});
+  })
+})
 
 describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
   beforeEach(() => {
@@ -602,7 +601,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
         payload: 'hello ethereum',
       },
     };
-  });
+  })
 
   it('Should validate signature from addr0', async () => {
     const expected =
@@ -611,7 +610,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -619,7 +618,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
 
   it('Should validate signature from addr1', async () => {
     const expected =
@@ -628,7 +627,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 1;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -636,7 +635,8 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+
   it('Should validate signature from addr8', async () => {
     const expected =
       '60cadafdbb7cba590a37eeff854d2598af71904077312875ef7b4f525d4dcb52' + // r
@@ -644,7 +644,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 8;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -652,8 +652,8 @@ describe('Compare personal_sign signatures vs Ledger vectors (1)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
-});
+  })
+})
 
 describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
   beforeEach(() => {
@@ -669,7 +669,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
         payload: 'hello ethereum this is another message',
       },
     };
-  });
+  })
 
   it('Should validate signature from addr0', async () => {
     const expected =
@@ -678,7 +678,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -686,7 +686,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
 
   it('Should validate signature from addr1', async () => {
     const expected =
@@ -695,7 +695,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 1;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -703,7 +703,8 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+
   it('Should validate signature from addr8', async () => {
     const expected =
       'c748f3fbf9f517fbd33462a858b40615ab6747295c27b4a46568d7d08c1d9d32' + // r
@@ -711,7 +712,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 8;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -719,8 +720,8 @@ describe('Compare personal_sign signatures vs Ledger vectors (2)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
-});
+  })
+})
 
 describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
   beforeEach(() => {
@@ -736,7 +737,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
         payload: 'third vector yo',
       },
     };
-  });
+  })
 
   it('Should validate signature from addr0', async () => {
     const expected =
@@ -745,7 +746,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -753,7 +754,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
 
   it('Should validate signature from addr1', async () => {
     const expected =
@@ -762,7 +763,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 1;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -770,7 +771,8 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+
   it('Should validate signature from addr8', async () => {
     const expected =
       '3e55dbb101880960cb32c17237d3ceb9d5846cf2f68c5c4c504cb827ea6a2e73' + // r
@@ -778,7 +780,7 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 8;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected, 'Lattice sig does not match');
       const jsSig = signPersonalJS(msgReq.data.payload, msgReq.data.signerPath);
@@ -786,8 +788,8 @@ describe('Compare personal_sign signatures vs Ledger vectors (3)', () => {
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
-});
+  })
+})
 
 describe('Compare EIP712 signatures vs Ledger vectors (1)', () => {
   beforeEach(() => {
@@ -835,7 +837,7 @@ describe('Compare EIP712 signatures vs Ledger vectors (1)', () => {
         },
       },
     };
-  });
+  })
 
   it('Should validate signature from addr0', async () => {
     const expected =
@@ -844,13 +846,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (1)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+
   it('Should validate signature from addr1', async () => {
     const expected =
       '9e784c6388f6f938f94239c67dc764909b86f34ec29312f4c623138fd7192115' + // r
@@ -858,13 +861,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (1)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 1;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+  
   it('Should validate signature from addr8', async () => {
     const expected =
       '6e7e9bfc4773291713bb5cdc483057d43a95a5082920bdd1dd3470caf6f11155' + // r
@@ -872,14 +876,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (1)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 8;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
   });
-});
+})
 
 describe('Compare EIP712 signatures vs Ledger vectors (2)', () => {
   beforeEach(() => {
@@ -917,7 +921,7 @@ describe('Compare EIP712 signatures vs Ledger vectors (2)', () => {
         },
       },
     };
-  });
+  })
 
   it('Should validate signature from addr0', async () => {
     const expected =
@@ -926,13 +930,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (2)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+
   it('Should validate signature from addr1', async () => {
     const expected =
       'f5284359479eb32eefe88bd24de59e4fd656d82238c7752e7a576b7a875eb5ae' + // r
@@ -940,13 +945,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (2)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 1;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
+  })
+
   it('Should validate signature from addr8', async () => {
     const expected =
       'f7a94b7ba7e0fbab88472cb77c5c255ba36e60e9f90bf4073960082bb5ef17cf' + // r
@@ -954,14 +960,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (2)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 8;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
-});
+  })
+})
 
 describe('Compare EIP712 signatures vs Ledger vectors (3)', () => {
   beforeEach(() => {
@@ -999,7 +1005,7 @@ describe('Compare EIP712 signatures vs Ledger vectors (3)', () => {
         },
       },
     };
-  });
+  })
 
   it('Should validate signature from addr0', async () => {
     const expected =
@@ -1008,7 +1014,7 @@ describe('Compare EIP712 signatures vs Ledger vectors (3)', () => {
       '01'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
@@ -1022,7 +1028,7 @@ describe('Compare EIP712 signatures vs Ledger vectors (3)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 1;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
@@ -1036,14 +1042,14 @@ describe('Compare EIP712 signatures vs Ledger vectors (3)', () => {
       '00'; // v
     msgReq.data.signerPath[2] = HARDENED_OFFSET + 8;
     try {
-      const res: any = await helpers.execute(client, 'sign', msgReq);
+      const res = await helpers.execute(client, 'sign', msgReq);
       const sig = getSigStr(res.sig);
       expect(sig).to.equal(expected);
     } catch (err) {
       expect(err).to.equal(null, err.message);
     }
-  });
-});
+  })
+})
 
 describe('Test random personal_sign messages against JS signatures', () => {
   beforeEach(() => {
@@ -1051,24 +1057,19 @@ describe('Test random personal_sign messages against JS signatures', () => {
       true,
       'Unauthorized or critical failure. Aborting'
     );
-  });
-  // By now we know that Ledger signatures match JS signatures
-  // so we can generate a bunch of random test vectors and
-  // compare Lattice sigs vs the JS implementation.
-  //@ts-expect-error - it.each is not included in @types/mocha
-  it.each(
-    RANDOM_VEC_LABELS,
-    'Random sign_personal vector',
-    ['label'],
-    async (n, next) => {
-      try {
+  })
+
+  it('Should test random vectors', async () => {
+    try {
+      continueTests = false;
+      for (let i = 0; i < RANDOM_VEC.length; i++) {
         let res, jsSig, sig;
         const req = {
           currency: 'ETH_MSG',
           data: {
             signerPath: LEDGER_ROOT_PATH,
             protocol: 'signPersonal',
-            payload: RANDOM_VEC[n.number],
+            payload: RANDOM_VEC[i],
           },
         };
         // Address index 0
@@ -1089,17 +1090,13 @@ describe('Test random personal_sign messages against JS signatures', () => {
         res = await helpers.execute(client, 'sign', req);
         sig = getSigStr(res.sig);
         expect(sig).to.equal(jsSig, 'Addr8 sig failed');
-        setTimeout(() => {
-          next();
-        }, 1000);
-      } catch (err) {
-        setTimeout(() => {
-          next(err);
-        }, 1000);
       }
+      continueTests = true;
+    } catch (err) {
+      expect(err).to.equal(null, err);
     }
-  );
-});
+  })
+})
 
 describe('Teardown Test', () => {
   beforeEach(() => {


### PR DESCRIPTION
This PR cleans up a couple things in the test suite:

* Removes the `it-each` dependency, as it is not typescript compliant and can easily be replaced. Closes #246 
* Adds early exit mechanisms to all tests. This ensures the tests will exit on error and not keep making requests. Closes #293