### PR TITLE
Removes dependency of `crypto`

### DIFF
--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,19 +1,6 @@
 import { Buffer } from 'buffer/';
 import 'hash.js';
 
-type Hash = {
-  hash: Sha256Constructor | Ripemd160Constructor;
-  update: (x) => Hash;
-  digest: () => Buffer;
-};
-
-export type Crypto = {
-  get32RandomBytes: () => Buffer;
-  generateEntropy: () => Buffer;
-  randomBytes: (n: number) => Buffer;
-  createHash: (type) => Hash;
-};
-
 export type ABIRecord = {
   header: {
     sig: string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -280,3 +280,12 @@ export const promisifyCb = (resolve, reject, cb: (err: string, ...cbParams) => v
     return resolve(...params)
   }
 }
+
+// Create a buffer of size `n` and fill it with random data
+export const randomBytes = function(n) {
+  const buf = Buffer.alloc(n);
+  for (let i = 0; i < n; i++) {
+    buf[i] = Math.round(Math.random() * 255);
+  }
+  return buf;
+}

--- a/test/testAbi.ts
+++ b/test/testAbi.ts
@@ -1,12 +1,11 @@
 import { AbiCoder } from '@ethersproject/abi';
 import { expect } from 'chai';
-import crypto from 'crypto';
 import _ from 'lodash';
 import randomWords from 'random-words';
 import { question } from 'readline-sync';
 import seedrandom from 'seedrandom';
 import { ETH_ABI_LATTICE_FW_TYPE_MAP, getFwVersionConst, HARDENED_OFFSET } from '../src/constants';
-import { ensureHexBuffer } from '../src/util'
+import { ensureHexBuffer, randomBytes } from '../src/util'
 import abi from './../src/ethereumAbi';
 import helpers from './testUtil/helpers';
 
@@ -72,19 +71,19 @@ function isNumType(type) {
 function randNumVal(type) {
   switch (type) {
     case 'uint8':
-      return '0x' + crypto.randomBytes(1).toString('hex');
+      return '0x' + randomBytes(1).toString('hex');
     case 'uint16':
-      return '0x' + crypto.randomBytes(1 + randInt(1)).toString('hex');
+      return '0x' + randomBytes(1 + randInt(1)).toString('hex');
     case 'uint24':
-      return '0x' + crypto.randomBytes(1 + randInt(2)).toString('hex');
+      return '0x' + randomBytes(1 + randInt(2)).toString('hex');
     case 'uint32':
-      return '0x' + crypto.randomBytes(1 + randInt(3)).toString('hex');
+      return '0x' + randomBytes(1 + randInt(3)).toString('hex');
     case 'uint64':
-      return '0x' + crypto.randomBytes(1 + randInt(7)).toString('hex');
+      return '0x' + randomBytes(1 + randInt(7)).toString('hex');
     case 'uint128':
-      return '0x' + crypto.randomBytes(1 + randInt(15)).toString('hex');
+      return '0x' + randomBytes(1 + randInt(15)).toString('hex');
     case 'uint256':
-      return '0x' + crypto.randomBytes(1 + randInt(31)).toString('hex');
+      return '0x' + randomBytes(1 + randInt(31)).toString('hex');
     default:
       throw new Error(`Unsupported type: ${type}`);
   }
@@ -95,15 +94,15 @@ function randBool() {
 }
 
 function randAddress() {
-  return `0x${crypto.randomBytes(20).toString('hex')}`;
+  return `0x${randomBytes(20).toString('hex')}`;
 }
 
 function randBytes(type) {
   const fixedSz = parseInt(type.slice(5));
   if (isNaN(fixedSz)) {
-    return crypto.randomBytes(1 + randInt(99)); // up to 100 bytes of random data
+    return randomBytes(1 + randInt(99)); // up to 100 bytes of random data
   } else {
-    return crypto.randomBytes(fixedSz); // Fixed number of bytes
+    return randomBytes(fixedSz); // Fixed number of bytes
   }
 }
 
@@ -589,7 +588,7 @@ describe('Test ABI fetch, create, delete', () => {
       },
     ],
     _typeNames: [ 'address' ],
-    _vals: [ `0x${crypto.randomBytes(20)} `]
+    _vals: [ `0x${randomBytes(20)} `]
   }
   TEST_DEF.sig = buildFuncSelector(TEST_DEF);
   beforeEach(() => {

--- a/test/testAll.ts
+++ b/test/testAll.ts
@@ -2,6 +2,7 @@
 import { expect } from 'chai';
 import { question } from 'readline-sync';
 import { getFwVersionConst, HARDENED_OFFSET, responseCodes, responseMsgs } from '../src/constants';
+import { randomBytes } from '../src/util'
 import helpers from './testUtil/helpers';
 
 let client, id;
@@ -218,9 +219,7 @@ describe('Connect and Pair', () => {
       expect(tx.tx).to.not.equal(null);
       req.data.chainId = 'rinkeby';
 
-      req.data.data = client.crypto
-        .randomBytes(fwConstants.ethMaxDataSz)
-        .toString('hex');
+      req.data.data = randomBytes(fwConstants.ethMaxDataSz).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
       expect(tx.tx).to.not.equal(null);
       req.data.data = null;
@@ -303,21 +302,19 @@ describe('Connect and Pair', () => {
       const maxDataSz =
         fwConstants.ethMaxDataSz +
         fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
-      req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
+      req.data.data = randomBytes(maxDataSz).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
       expect(tx.tx).to.not.equal(null);
       question(
         'Please ACCEPT the following transaction only if the warning screen displays. Press enter to continue.'
       );
-      req.data.data = client.crypto.randomBytes(maxDataSz + 1).toString('hex');
+      req.data.data = randomBytes(maxDataSz + 1).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
       expect(tx.tx).to.not.equal(null);
-      req.data.data = client.crypto
-        .randomBytes(fwConstants.ethMaxDataSz)
-        .toString('hex');
+      req.data.data = randomBytes(fwConstants.ethMaxDataSz).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
       expect(tx.tx).to.not.equal(null);
-      req.data.data = client.crypto.randomBytes(maxDataSz).toString('hex');
+      req.data.data = randomBytes(maxDataSz).toString('hex');
       tx = await helpers.execute(client, 'sign', req);
       expect(tx.tx).to.not.equal(null);
 

--- a/test/testChaosMonkey.ts
+++ b/test/testChaosMonkey.ts
@@ -15,10 +15,10 @@
 
 import { Byte } from "bitwise/types";
 import { signingSchema } from "../src/constants";
+import { sha256 } from 'hash.js/lib/hash/sha'
 
 const { expect } = require('chai');
 const Sdk = require('../src/index');
-const crypto = require('crypto');
 const question = require('readline-sync').question;
 import helpers from './testUtil/helpers';
 
@@ -53,10 +53,7 @@ const CONNECT_AND_PAIR_LATTICE = (
         Buffer.from(appName)
       ]
     )
-    return crypto
-      .createHash('sha256')
-      .update(privKeyPreImage)
-      .digest()
+    return Buffer.from(sha256().update(privKeyPreImage).digest('hex'), 'hex');
   })()
 
   //--------------------------------------------------------------------------
@@ -65,7 +62,6 @@ const CONNECT_AND_PAIR_LATTICE = (
   const clientOpts = {
     name: appName,
     baseUrl: baseUrl,
-    crypto,
     timeout: 180000,
     privKey: privateKey
   }

--- a/test/testEth.ts
+++ b/test/testEth.ts
@@ -17,10 +17,10 @@
 import { serialize } from '@ethersproject/transactions';
 import BN from 'bignumber.js';
 import { expect } from 'chai';
-import crypto from 'crypto';
 import seedrandom from 'seedrandom';
 import { question } from 'readline-sync';
 import { getFwVersionConst, HARDENED_OFFSET } from '../src/constants';
+import { randomBytes } from '../src/util'
 import helpers from './testUtil/helpers';
 const prng = new seedrandom(process.env.SEED || 'myrandomseed');
 let client = null;
@@ -62,8 +62,8 @@ function buildRandomTxData(fwConstants) {
         ETH_GAS_LIMIT_MIN + randInt(ETH_GAS_LIMIT_MAX - ETH_GAS_LIMIT_MIN)
       ).toString(16)}`,
       value: `0x${new BN(randInt(10 ** randInt(30))).toString(16)}`,
-      to: `0x${crypto.randomBytes(20).toString('hex')}`,
-      data: `0x${crypto.randomBytes(randInt(maxDataSz)).toString('hex')}`,
+      to: `0x${randomBytes(20).toString('hex')}`,
+      data: `0x${randomBytes(randInt(maxDataSz)).toString('hex')}`,
       eip155: randInt(2) > 0 ? true : false,
       // 51 is the max bit size that we can validate with our bignum lib (see chainID section)
       _network: getChainId(randInt(52), 0),
@@ -320,7 +320,7 @@ if (!process.env.skip) {
     it('Should test range of chainId sizes and EIP155 tag', async () => {
       const txData = JSON.parse(JSON.stringify(defaultTxData));
       // Add some random data for good measure, since this will interact with the data buffer
-      txData.data = `0x${crypto.randomBytes(randInt(100)).toString('hex')}`;
+      txData.data = `0x${randomBytes(randInt(100)).toString('hex')}`;
 
       let chainId: any = 1;
       // This one can fit in the normal chainID u8
@@ -392,24 +392,16 @@ if (!process.env.skip) {
         fwConstants.ethMaxDataSz -
         metadataSz +
         fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
-      txData.data = `0x${crypto
-        .randomBytes(maxDataSz - chainIdSz)
-        .toString('hex')}`;
+      txData.data = `0x${randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
       await testTxPass(buildTxReq(txData, chainId));
-      txData.data = `0x${crypto
-        .randomBytes(maxDataSz - chainIdSz + 1)
-        .toString('hex')}`;
+      txData.data = `0x${randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
       await testTxFail(buildTxReq(txData, chainId));
       // Also test smaller sizes
       chainId = getChainId(16, -1);
       chainIdSz = 3;
-      txData.data = `0x${crypto
-        .randomBytes(maxDataSz - chainIdSz)
-        .toString('hex')}`;
+      txData.data = `0x${randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
       await testTxPass(buildTxReq(txData, chainId));
-      txData.data = `0x${crypto
-        .randomBytes(maxDataSz - chainIdSz + 1)
-        .toString('hex')}`;
+      txData.data = `0x${randomBytes(maxDataSz - chainIdSz + 1).toString('hex')}`;
       await testTxFail(buildTxReq(txData, chainId));
     })
 

--- a/test/testEthMsg.ts
+++ b/test/testEthMsg.ts
@@ -15,10 +15,10 @@
 // NOTE: It is highly suggested that you set `AUTO_SIGN_DEV_ONLY=1` in the firmware
 //        root CMakeLists.txt file (for dev units)
 import { expect } from 'chai';
-import crypto from 'crypto';
 import randomWords from 'random-words';
 import seedrandom from 'seedrandom';
 import { getFwVersionConst, HARDENED_OFFSET } from '../src/constants';
+import { randomBytes } from '../src/util'
 import helpers from './testUtil/helpers';
 const prng = new seedrandom(process.env.SEED || 'myrandomseed');
 let client = null;
@@ -36,7 +36,7 @@ function buildRandomMsg(type = 'signPersonal') {
     const isHexStr = randInt(2) > 0 ? true : false;
     const fwConstants = getFwVersionConst(client.fwVersion);
     const L = randInt(fwConstants.ethMaxDataSz - MSG_PAYLOAD_METADATA_SZ);
-    if (isHexStr) return `0x${crypto.randomBytes(L).toString('hex')}`;
+    if (isHexStr) return `0x${randomBytes(L).toString('hex')}`;
     // Get L hex bytes (represented with a string with 2*L chars)
     else return randomWords({ exactly: L, join: ' ' }).slice(0, L); // Get L ASCII characters (bytes)
   } else if (type === 'eip712') {
@@ -131,7 +131,7 @@ describe('Test ETH personalSign', function () {
   });
 
   it('Should test a message that needs to be prehashed', async () => {
-    await testMsg(buildMsgReq(crypto.randomBytes(4000), 'signPersonal'));
+    await testMsg(buildMsgReq(randomBytes(4000), 'signPersonal'));
   });
 
   it('Msg: sign_personal boundary conditions and auto-rejected requests', async () => {
@@ -146,8 +146,8 @@ describe('Test ETH personalSign', function () {
       metadataSz -
       fwConstants.personalSignHeaderSz +
       fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
-    const maxValid = `0x${crypto.randomBytes(maxMsgSz).toString('hex')}`;
-    const minInvalid = `0x${crypto.randomBytes(maxMsgSz + 1).toString('hex')}`;
+    const maxValid = `0x${randomBytes(maxMsgSz).toString('hex')}`;
+    const minInvalid = `0x${randomBytes(maxMsgSz + 1).toString('hex')}`;
     const zeroInvalid = '0x';
     // The largest non-hardened index which will take the most chars to print
     const x = HARDENED_OFFSET - 1;
@@ -196,7 +196,7 @@ describe('Test ETH EIP712', function () {
       primaryType: 'dYdX',
       message: {
         action: 'dYdX STARK Key',
-        onlySignOn: crypto.randomBytes(4000).toString('hex'),
+        onlySignOn: randomBytes(4000).toString('hex'),
       },
     };
     await testMsg(buildMsgReq(msg, 'eip712'));

--- a/test/testSigs.ts
+++ b/test/testSigs.ts
@@ -2,12 +2,12 @@
 import bip32 from 'bip32';
 import { mnemonicToSeedSync } from 'bip39';
 import { expect } from 'chai';
-import crypto from 'crypto';
 import { ecsign, privateToAddress } from 'ethereumjs-util';
 import { keccak256 } from 'js-sha3';
 import { question } from 'readline-sync';
 import seedrandom from 'seedrandom';
 import { HARDENED_OFFSET } from '../src/constants';
+import { randomBytes } from '../src/util'
 import helpers from './testUtil/helpers';
 
 //---------
@@ -514,7 +514,7 @@ describe('Test uniformity of Ethereum transaction sigs', () => {
 
   it('Should validate uniformity of 5 consecutive tx signatures (with oversized data)', async () => {
     try {
-      txReq.data.data = `0x${crypto.randomBytes(4000).toString('hex')}`;
+      txReq.data.data = `0x${randomBytes(4000).toString('hex')}`;
       txReq.data.signerPath[2] = HARDENED_OFFSET;
       const tx1_addr0 = await helpers.execute(client, 'sign', txReq);
       const tx2_addr0 = await helpers.execute(client, 'sign', txReq);

--- a/test/testUtil/helpers.ts
+++ b/test/testUtil/helpers.ts
@@ -2,7 +2,6 @@ import bip32 from 'bip32';
 import { wordlists } from 'bip39';
 import bitcoin from 'bitcoinjs-lib';
 import { expect as expect } from 'chai';
-import crypto from 'crypto';
 import { derivePath as deriveEDKey, getPublicKey as getEDPubkey } from 'ed25519-hd-key'
 import { ec as EC, eddsa as EdDSA } from 'elliptic';
 import { privateToAddress } from 'ethereumjs-util';
@@ -12,7 +11,7 @@ import {
   ADDR_STR_LEN, BIP_CONSTANTS, ethMsgProtocol, HARDENED_OFFSET, 
 } from '../../src/constants';
 import { Client, Constants } from '../../src/index';
-import { parseDER } from '../../src/util';
+import { parseDER, randomBytes } from '../../src/util';
 const SIGHASH_ALL = 0x01;
 const secp256k1 = new EC('secp256k1');
 const ed25519 = new EdDSA('ed25519');
@@ -32,7 +31,6 @@ function setupTestClient(env) {
   const setup: any = {
     name: env.name || 'SDK Test',
     baseUrl: env.baseUrl || 'https://signing.gridpl.us',
-    crypto,
     timeout: 120000,
   };
   const REUSABLE_KEY =
@@ -789,23 +787,23 @@ export const buildRandomEip712Object = function (randInt) {
   }
   function getRandomEIP712Val(type) {
     if (type !== 'bytes' && type.slice(0, 5) === 'bytes') {
-      return `0x${crypto.randomBytes(parseInt(type.slice(5))).toString('hex')}`;
+      return `0x${randomBytes(parseInt(type.slice(5))).toString('hex')}`;
     } else if (type === 'uint' || type === 'int') {
-      return `0x${crypto.randomBytes(32).toString('hex')}`;
+      return `0x${randomBytes(32).toString('hex')}`;
     } else if (type.indexOf('uint') > -1) {
-      return `0x${crypto.randomBytes(parseInt(type.slice(4)))}`;
+      return `0x${randomBytes(parseInt(type.slice(4)))}`;
     } else if (type.indexOf('int') > -1) {
-      return `0x${crypto.randomBytes(parseInt(type.slice(3)))}`;
+      return `0x${randomBytes(parseInt(type.slice(3)))}`;
     }
     switch (type) {
       case 'bytes':
-        return `0x${crypto.randomBytes(1 + randInt(50)).toString('hex')}`;
+        return `0x${randomBytes(1 + randInt(50)).toString('hex')}`;
       case 'string':
         return randStr(100);
       case 'bool':
         return randInt(1) > 0 ? true : false;
       case 'address':
-        return `0x${crypto.randomBytes(20).toString('hex')}`;
+        return `0x${randomBytes(20).toString('hex')}`;
       default:
         throw new Error('unsupported eip712 type');
     }
@@ -838,7 +836,7 @@ export const buildRandomEip712Object = function (randInt) {
       name: `Domain_${getRandomName(true)}`,
       version: '1',
       chainId: `0x${(1 + randInt(15000)).toString(16)}`,
-      verifyingContract: `0x${crypto.randomBytes(20).toString('hex')}`,
+      verifyingContract: `0x${randomBytes(20).toString('hex')}`,
     },
     message: {},
   };

--- a/test/testWalletJobs.ts
+++ b/test/testWalletJobs.ts
@@ -18,12 +18,12 @@ import { mnemonicToSeedSync } from 'bip39';
 import ethjsBN from 'bn.js';
 import { expect } from 'chai';
 import cli from 'cli-interact';
-import crypto from 'crypto';
 import { ecrecover, privateToAddress, privateToPublic, publicToAddress } from 'ethereumjs-util';
 import { keccak256 } from 'js-sha3';
 import { decode, encode } from 'rlp';
 import seedrandom from 'seedrandom';
 import { getFwVersionConst, HARDENED_OFFSET } from '../src/constants';
+import { randomBytes } from '../src/util'
 import { Constants } from '../src/index'
 import helpers from './testUtil/helpers';
 let client,
@@ -126,7 +126,7 @@ describe('exportSeed', () => {
   });
 
   it('Should get GP_ENODEV for unknown (random) wallet', async () => {
-    const dummyWalletUID = crypto.randomBytes(32);
+    const dummyWalletUID = randomBytes(32);
     jobReq.payload = helpers.serializeJobData(jobType, dummyWalletUID, jobData);
     await runTestCase(helpers.gpErrors.GP_ENODEV);
   });
@@ -161,7 +161,7 @@ describe('getAddresses', () => {
   });
 
   it('Should get GP_EWALLET for unknown (random) wallet', async () => {
-    const dummyWalletUID = crypto.randomBytes(32);
+    const dummyWalletUID = randomBytes(32);
     jobReq.payload = helpers.serializeJobData(jobType, dummyWalletUID, jobData);
     await runTestCase(helpers.gpErrors.GP_EWALLET);
   });
@@ -603,7 +603,7 @@ describe('signTx', () => {
       numRequests: 1,
       sigReq: [
         {
-          data: crypto.randomBytes(32),
+          data: randomBytes(32),
           signerPath: path,
         },
       ],
@@ -675,7 +675,7 @@ describe('signTx', () => {
   });
 
   it('Should get GP_EWALLET for unknown (random) wallet', async () => {
-    const dummyWalletUID = crypto.randomBytes(32);
+    const dummyWalletUID = randomBytes(32);
     jobReq.payload = helpers.serializeJobData(jobType, dummyWalletUID, jobData);
     await runTestCase(helpers.gpErrors.GP_EWALLET);
   });
@@ -1041,7 +1041,7 @@ describe('deleteSeed', () => {
   });
 
   it('Should get GP_EINVAL for unknown (random) wallet', async () => {
-    const dummyWalletUID = crypto.randomBytes(32);
+    const dummyWalletUID = randomBytes(32);
     jobReq.payload = helpers.serializeJobData(jobType, dummyWalletUID, jobData);
     await runTestCase(helpers.gpErrors.GP_EINVAL);
   });


### PR DESCRIPTION
Only two functions were even being used. One of them can be replaced with
hashing functions from `hash.js`. The other can be replaced with any
pseudorandom number generator and a util function.
Also removes `key` from the constructor, as it was unused.
Closes #295