### PR TITLE
Calldata decoder mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "ed25519-hd-key": "^1.2.0",
         "eslint": "^8.7.0",
         "ethereumjs-util": "^7.1.4",
+        "jsonc": "^2.0.0",
         "lodash": ">=4.17.21",
         "minimist": ">=0.2.1",
         "mocha": "^9.2.0",
@@ -2223,6 +2224,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -2648,6 +2658,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "node_modules/fastq": {
@@ -3126,6 +3142,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3373,6 +3395,12 @@
         "jscrypto": "bin/cli.js"
       }
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -3417,6 +3445,32 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsonc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
+      "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+      "dev": true,
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.6",
+        "graceful-fs": "^4.1.15",
+        "mkdirp": "^0.5.1",
+        "parse-json": "^4.0.0",
+        "strip-bom": "^4.0.0",
+        "strip-json-comments": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsonc/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jsonparse": {
@@ -3900,6 +3954,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/path-exists": {
@@ -6878,6 +6945,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -7216,6 +7292,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "fastq": {
@@ -7557,6 +7639,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -7753,6 +7841,12 @@
       "integrity": "sha512-lryZl0flhodv4SZHOqyb1bx5sKcJxj0VBo0Kzb4QMAg3L021IC9uGpl0RCZa+9KJwlRGSK2C80ITcwbe19OKLQ==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -7794,6 +7888,28 @@
       "optional": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
+      "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.6",
+        "graceful-fs": "^4.1.15",
+        "mkdirp": "^0.5.1",
+        "parse-json": "^4.0.0",
+        "strip-bom": "^4.0.0",
+        "strip-json-comments": "^3.0.1"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        }
       }
     },
     "jsonparse": {
@@ -8152,6 +8268,16 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "path-exists": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "mocha": "^9.2.0",
         "random-words": "^1.1.1",
         "readline-sync": "^1.4.9",
+        "request-promise": "^4.2.6",
         "seedrandom": "^3.0.5",
         "ts-mocha": "^9.0.2",
         "typescript": "^4.5.4"
@@ -1375,6 +1376,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1388,6 +1409,23 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/axios": {
       "version": "0.24.0",
@@ -1430,6 +1468,23 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/bech32": {
       "version": "2.0.0",
@@ -1547,6 +1602,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "4.12.0",
@@ -1740,6 +1801,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -1968,6 +2036,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -2086,6 +2167,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ed25519-hd-key": {
@@ -2493,6 +2585,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "peer": true
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -2651,6 +2753,16 @@
         }
       }
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -2733,6 +2845,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -2823,6 +2945,31 @@
         "node": ">=4.x"
       }
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2893,6 +3040,22 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
     "node_modules/ieee754": {
@@ -3023,6 +3186,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3062,6 +3232,13 @@
       "peerDependencies": {
         "ws": "*"
       }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/jayson": {
       "version": "3.6.6",
@@ -3180,6 +3357,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/jscrypto": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/jscrypto/-/jscrypto-1.0.3.tgz",
@@ -3188,6 +3372,13 @@
       "bin": {
         "jscrypto": "bin/cli.js"
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3251,6 +3442,22 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/keccak": {
@@ -3609,6 +3816,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -3745,6 +3962,13 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3838,6 +4062,12 @@
       "version": "17.0.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.17.tgz",
       "integrity": "sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==",
+      "dev": true
+    },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "node_modules/punycode": {
@@ -3962,6 +4192,109 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -4098,6 +4431,13 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
@@ -4226,6 +4566,39 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -4245,6 +4618,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/string_decoder": {
@@ -4436,6 +4818,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4526,6 +4921,19 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tweetnacl": {
@@ -4636,6 +5044,28 @@
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -5745,6 +6175,23 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "peer": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -5755,6 +6202,20 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "peer": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true,
+      "peer": true
     },
     "axios": {
       "version": "0.24.0",
@@ -5783,6 +6244,25 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true,
+          "peer": true
+        }
+      }
     },
     "bech32": {
       "version": "2.0.0",
@@ -5890,6 +6370,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "bn.js": {
       "version": "4.12.0",
@@ -6049,6 +6535,13 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true,
+      "peer": true
     },
     "chai": {
       "version": "4.3.6",
@@ -6237,6 +6730,16 @@
         "which": "^2.0.1"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -6317,6 +6820,17 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ed25519-hd-key": {
@@ -6649,6 +7163,13 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "peer": true
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -6768,6 +7289,13 @@
       "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "peer": true
+    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -6827,6 +7355,16 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -6893,6 +7431,24 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "peer": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6945,6 +7501,18 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "ieee754": {
@@ -7031,6 +7599,13 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true,
+      "peer": true
+    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -7059,6 +7634,13 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "dev": true,
       "requires": {}
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true,
+      "peer": true
     },
     "jayson": {
       "version": "3.6.6",
@@ -7158,11 +7740,25 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "peer": true
+    },
     "jscrypto": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/jscrypto/-/jscrypto-1.0.3.tgz",
       "integrity": "sha512-lryZl0flhodv4SZHOqyb1bx5sKcJxj0VBo0Kzb4QMAg3L021IC9uGpl0RCZa+9KJwlRGSK2C80ITcwbe19OKLQ==",
       "dev": true
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "peer": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -7214,6 +7810,19 @@
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
       }
     },
     "keccak": {
@@ -7483,6 +8092,13 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "peer": true
+    },
     "object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -7580,6 +8196,13 @@
         "sha.js": "^2.4.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "peer": true
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -7649,6 +8272,12 @@
           "dev": true
         }
       }
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",
@@ -7736,6 +8365,84 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+          "dev": true,
+          "peer": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7813,6 +8520,13 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "peer": true
     },
     "scrypt-js": {
       "version": "3.0.1",
@@ -7914,6 +8628,33 @@
         "source-map": "^0.6.0"
       }
     },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -7930,6 +8671,12 @@
           "dev": true
         }
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -8090,6 +8837,16 @@
         "is-number": "^7.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -8156,6 +8913,16 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -8239,6 +9006,27 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "mocha": "^9.2.0",
     "random-words": "^1.1.1",
     "readline-sync": "^1.4.9",
+    "request-promise": "^4.2.6",
     "seedrandom": "^3.0.5",
     "ts-mocha": "^9.0.2",
     "typescript": "^4.5.4"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ed25519-hd-key": "^1.2.0",
     "eslint": "^8.7.0",
     "ethereumjs-util": "^7.1.4",
+    "jsonc": "^2.0.0",
     "lodash": ">=4.17.21",
     "minimist": ">=0.2.1",
     "mocha": "^9.2.0",

--- a/src/calldata/evm.ts
+++ b/src/calldata/evm.ts
@@ -1,0 +1,199 @@
+import { Buffer } from 'buffer/';
+import { keccak256 } from 'js-sha3';
+import { encode } from 'rlp';
+
+/**
+* Look through the response of an Etherescan ABI request to see
+* if there is a function that matches the signature provided.
+* @param sig    a 0x-prefixed hex string containing 4 bytes of info
+* @param resp   the response of Etherscan's `getabi` API call
+* @returns      Buffer containing RLP-serialized array of 
+*               calldata info to pass to signing request
+*/ 
+export const searchEtherscanAbiDef = function(sig, resp): Buffer {
+  if (typeof sig !== 'string' || (sig.length !== 10 && sig.length !== 8)) {
+    throw new Error('`sig` must be a hex string with 4 bytes of data.')
+  }
+  if (sig.length === 8) {
+    sig = `0x${sig}`;
+  }
+  if (typeof resp === 'string') {
+    resp = JSON.parse(resp);
+  }
+  const abiData = JSON.parse(resp.result);
+  let match = null;
+  abiData.forEach((item) => {
+    const def = parseDef(item);
+    if (def) {
+      // If this matches the function selector (sig) we can return it
+      const defSig = `0x${keccak256(def.canonicalName).slice(0, 8)}`;
+      if (def && defSig === sig) {
+        match = def.def;
+      }
+    }
+  })
+  if (match) {
+    console.log(JSON.stringify(match, null, 2))
+    return Buffer.from(encode(match));
+  }
+  return null;
+}
+
+// Parse an Etherscan definition into a calldata structure that the 
+// Lattice EVM decoder can handle. Returns a `def` of structure
+// [ 
+//    [ param1Name, param1Type, param1Sz ],
+//    [ param2Name, param2Type, param2Sz ],
+//    ...
+// ]
+function parseDef(item): EVMDef {
+  // Skip non-functions
+  if (item.type !== 'function') {
+    return;
+  }
+  return __parseDef(item, '', []);
+}
+
+function __parseDef(item, canonicalName, def=[], recursed=false): EVMDef {
+  // Function name. Can be an empty string.
+  if (!recursed) {
+    const nameStr = item.name || '';
+    def.push(nameStr)
+    canonicalName += nameStr;
+  }
+  // Loop through params
+  if (item.inputs) {
+    canonicalName += '(';
+    item.inputs.forEach((input) => {
+      const parsedParam = _parseParam(input);
+      if (input.type.indexOf('tuple') > -1 && input.components) {
+        // For tuples we need to recurse
+        const recursed = __parseDef(
+          { inputs: input.components }, canonicalName, [], true
+        );
+        canonicalName = recursed.canonicalName;
+        // Add brackets if this is a tuple array and also add
+        // a comma
+        canonicalName += `${input.type.slice(5)},`
+        parsedParam.push(recursed.def);
+      } else {
+        canonicalName += input.type;
+        canonicalName += ',';
+      }
+      def.push(parsedParam);
+    })
+    // Take off the last comma. Note that we do not want to slice
+    // if the last param was a tuple, since we want to keep that `)`
+    if (canonicalName[canonicalName.length - 1] === ',') {
+      canonicalName = canonicalName.slice(0, canonicalName.length - 1);
+    }
+    // Add the closing parens
+    canonicalName += ')';
+  }
+  return { def, canonicalName };
+}
+
+
+// Build an array of the following:
+// [ paramName, paramType, paramSzBytes, ...]
+// * paramName - name of the parameter. This piece of data is unverified,
+//   so it will display differently if the user has the function saved
+//   in secure storage.
+// * paramType - basic type of param. Firmware has an enum with 7 values.
+// * paramSzBytes - number of bytes representing this param. Only certain
+//   types can have nonzero value for this. For example, a `uint` with 
+//   a 4 in this slot would be uint32 (8*4 = 32). Maximum number of bytes
+//   is always 32 because these types can only be used in single 32 byte words.
+function _parseParam(input) {
+  if (!input.type) {
+    throw new Error('No type in input');
+  }
+  const param = [ input.name ];
+  const { typeIdx, szBytes, arraySzs} = _getParamTypeInfo(input.type);
+  param.push(typeIdx);
+  param.push(szBytes);
+  param.push(arraySzs);
+  return param;
+}
+
+function _getParamTypeInfo(type): EVMParamInfo {
+  const TYPES = {
+    'address': 1, 'bool': 2, 'uint': 3, 'int': 4, 
+    'bytes': 5, 'string': 6, 'tuple': 7,
+  };
+  const param: EVMParamInfo = {
+    szBytes: 0,
+    typeIdx: 0,
+    arraySzs: [],
+  };
+  let baseType;
+  Object.keys(TYPES).forEach((k) => {
+    if (type.indexOf(k) > -1 && !baseType) {
+      baseType = k;
+      param.typeIdx = TYPES[k];
+    }
+  })
+  // Get the array size, if any
+  param.arraySzs = _getArraySzs(type);
+  // Determine where to search for expanded size
+  const szIdx = param.arraySzs.length > 0 ?
+                type.indexOf('[') :
+                type.length;
+  if (['uint', 'int', 'bytes'].indexOf(baseType) > -1) {
+    // If this can have a fixed size, capture that
+    const szBits = parseInt(
+      type.slice(baseType.length, szIdx)
+    ) || 0;
+    if (szBits > 256) {
+      throw new Error('Invalid param size');
+    }
+    param.szBytes = szBits / 8;
+  } else {
+    // No fixed size in the type
+    param.szBytes = 0;
+  }
+  return param;
+}
+
+// Determine the dimensions of an array type. These dimensions can
+// be either fixed or variable size. Returns an array of sizes.
+// Ex: uint256[][] -> [0, 0], uint256[1][3] -> [1, 3], uint256 -> []
+function _getArraySzs(type): number[] {
+  if (typeof type !== 'string') {
+    throw new Error('Invalid type')
+  }
+  const szs = [];
+  let t1 = type;
+  while (t1.length > 0) {
+    const openIdx = t1.indexOf('[')
+    if (openIdx < 0) {
+      return szs;
+    }
+    const t2 = t1.slice(openIdx);
+    const closeIdx = t2.indexOf(']');
+    if (closeIdx < 0) {
+      throw new Error('Bad param type');
+    }
+    const t3 = t2.slice(1, closeIdx);
+    if (t3.length === 0) {
+      // Variable size
+      szs.push(0);
+    } else {
+      // Fixed size
+      szs.push(parseInt(t3));
+    }
+    t1 = t2.slice(closeIdx + 1);
+  }
+  return szs;
+}
+
+type EVMParamInfo = {
+  szBytes: number;
+  typeIdx: number;
+  arraySzs: number[];
+}
+
+type EVMDef = {
+  canonicalName: string;
+  def: any;
+}

--- a/src/calldata/index.ts
+++ b/src/calldata/index.ts
@@ -1,0 +1,7 @@
+/**
+* Exports containing utils that allow inclusion of calldata
+* decoder info in signing requests. If calldata decoder info
+* is packed into the request, it is used to decode the calldata
+* in the request. It is optional.
+*/
+export { searchEtherscanAbiDef } from './evm';

--- a/src/calldata/index.ts
+++ b/src/calldata/index.ts
@@ -4,4 +4,4 @@
 * is packed into the request, it is used to decode the calldata
 * in the request. It is optional.
 */
-export { searchEtherscanAbiDef } from './evm';
+export { parseSolidityJSONABI, parseCanonicalName } from './evm';

--- a/src/client.ts
+++ b/src/client.ts
@@ -423,7 +423,6 @@ export class Client {
             try {
               payload = ethereum.ethConvertLegacyToGenericReq(data);
             } catch (err) {
-              console.log(err)
               return cb(`Please update Lattice firmware. Request failed. ${err.message}`);
             }
             data = {

--- a/src/client.ts
+++ b/src/client.ts
@@ -940,7 +940,7 @@ export class Client {
    * @internal
    * @returns callback
    */
-  private _getActiveWallet (cb, forceRefresh = false) {
+  public _getActiveWallet (cb, forceRefresh = false) {
     if (
       forceRefresh !== true &&
       (this.hasActiveWallet() === true || this.isPaired !== true)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -471,6 +471,11 @@ function getFwVersionConst(v) {
   // V0.15.0 added an EVM decoder and removed the legacy ETH signing pathway
   if (!legacy && gte(v, [0, 15, 0])) {
       c.genericSigning.encodingTypes.EVM = EXTERNAL.SIGNING.ENCODINGS.EVM;
+      // Code used to write a calldata decoder
+      c.genericSigning.calldataDecoding = {
+        reserved: 2895728,
+        maxSz: 1024,
+      };
   }
 
   return c;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Client } from './client';
 export { EXTERNAL as Constants } from './constants'
+export * as Calldata from './calldata/index'

--- a/test/signing/index.ts
+++ b/test/signing/index.ts
@@ -83,7 +83,8 @@ describe('Test General Signing', () => {
     const data = helpers.deserializeExportSeedJobResult(_res.result);
     global.test.seed = helpers.copyBuffer(data.seed);
   })
-/*
+
+  /*
   it('Should load unformatted Tests', async () => {
     require('./unformatted');
   })

--- a/test/signing/index.ts
+++ b/test/signing/index.ts
@@ -45,6 +45,7 @@ describe('Test General Signing', () => {
       runGeneric,
       prng: new seedrandom(process.env.SEED || Math.random().toString()),
       numIter: process.env.N || 5,
+      etherscanKey: process.env.ETHERSCAN_KEY,
     };
     expect(global.test.client).to.not.equal(null);
   })
@@ -82,19 +83,19 @@ describe('Test General Signing', () => {
     const data = helpers.deserializeExportSeedJobResult(_res.result);
     global.test.seed = helpers.copyBuffer(data.seed);
   })
+/*
+  it('Should load unformatted Tests', async () => {
+    require('./unformatted');
+  })
 
-  // it('Should load unformatted Tests', async () => {
-  //   require('./unformatted');
-  // })
-
-  // it('Should load Solana Tests', async () => {
-  //   require('./solana');
-  // })
+  it('Should load Solana Tests', async () => {
+    require('./solana');
+  })
 
   it('Should load Terra Tests' , async () => {
     require('./terra');
   })
-
+*/
   it('Should load EVM Tests' , async () => {
     require('./evm');
   })

--- a/test/signing/vectors.jsonc
+++ b/test/signing/vectors.jsonc
@@ -1,0 +1,132 @@
+// Vectors for signing tests
+{
+  "evm": {
+    // We use these vectors to test just-in-type calldata decoding for EVM transactions.
+    // The relevant protocol is Ethereum ABI serdes: https://docs.soliditylang.org/en/develop/abi-spec.html
+    "calldata": {
+      // ETH Mainnet transactions interacting with contracts. We use these
+      // to simulate a production environment of fetching ABI data and adding
+      // decoding info to the request.
+      "etherscanTxHashes": [
+        //  swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, 
+        //  address to, uint256 deadline)
+        "0xeee0752109c6d31038bab6c2b0a3e3857e8bffb9c229de71f0196fda6fb28a5e",
+        //  remove_liquidity_one_coin(uint256 _token_amount, int128 i, uint256 _min_amount)
+        "0xa6173b4890303e12ca1b195ea4a04d8891b0d83768b734d2ecdb9c6dd9d828c4",
+        //  atomicMatch_(address[14],uint256[18],uint8[8],bytes,bytes,bytes,bytes,bytes,bytes,
+        //  uint8[2],bytes32[5])
+        // this one is too large for 1 frame       
+        // "0x92c82aad37a925e3aabe3d603109a5e65993aa2615c4b2278c3d355d9d433dff",
+        //  exactInput((bytes,address,uint256,uint256,uint256))
+        "0xee9710119c13dba6fe2de240ef1e24a2489e98d9c7dd5881e2901056764ee234",
+        //  exactInputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160))
+        "0xc33308ca105630b99a0c24ddde4f4506aa4115ec6f1a25f1138f3bd8cfa32b49",
+        //  proveAndClaimWithResolver(bytes,(bytes,bytes)[],bytes,address,address)
+        "0xe15e6205c6696d444fc426468defdf08e89a0f5b3b8a17c68428f7aeefd53ca1"
+      ],
+      // These are canonical ABI definitions that we use to test more unusual function types.
+      // The names are parsed and dummy data is filled in (see helpers in ./evm.ts).
+      // The accompanying tests also have some helpful print lines which are commented out
+      // by default but are useful for debugging.
+      // The purpose of these is to ensure all (most) ABI structures can be decoded.
+      // A few of these towards the end are not supported but they are such edge cases that
+      // it's not worth worrying about them for now.
+      "canonicalNames": [
+        // ---
+        // Test a few vectors we alredy checked with Etherscan
+        // ---
+        "swapExactTokensForTokens(uint256,uint256,address[],address,uint256)",
+        "proveAndClaimWithResolver((bytes,bytes)[])",
+        "proveAndClaimWithResolver(bytes,(bytes,bytes)[])",
+        "proveAndClaimWithResolver(bytes,(bytes,bytes)[],bytes,address,address)",
+        "remove_liquidity_one_coin(uint256,int128,uint256)",
+        // ---
+        // Made up vectors that should all decode
+        // ---
+        "multidimArr(uint256[][],bool)",
+        "multidimArr(uint256[2][])",
+        "multidimArr(uint256[][2])",
+        "multidimArr(uint256[2],bool)",
+        "multidimArr(uint256[2][2],bool)",
+        "multidimArr(uint256[2][2][2],bool)",
+        "multidimArr(uint256[2][2],bool)",
+        "multidimArr(uint256[][][],bool)",
+        "multidimArr(bool,uint256[],bool)",
+        "multidimArr(bytes,uint256[][],bool)",
+        "singleTup((uint256,uint256))",
+        "singleTup((uint256[]))",
+        "singleTup((uint256[],bool))",
+        "singleTup((bool,bool,uint[],uint256))",
+        "singleTup((uint256[1],uint256[]))",
+        "singleTup((bytes,uint256))",
+        "singleTup((bytes,uint256)[])",
+        "singleTup((uint256,uint256)[])",
+        "singleTup((uint256,uint256)[2])",
+        "singleTup((uint256[2],uint256))",
+        "singleTup((uint256,uint256)[2])",
+        "singleTup((uint256,uint256)[],bytes)",
+        "singleTup((uint256,uint256)[][],bytes)",
+        "singleTup((uint256,uint256)[2][],bytes)",
+        "singleTup((uint256,uint256)[][2],bytes)",
+        "singleTup((uint256,uint256)[2],bytes)",
+        "singleTup(bytes[],(uint256,uint256)[2],bytes)",
+        "singleTup(bytes[2],(uint256,uint256)[2],bytes)",
+        "singleTup((uint256,uint256)[2],bytes)",
+        "singleTup((uint256,uint256)[2][2],bytes)",
+        "singleTup((uint256,uint256)[2][2][2],bytes)",
+        "singleTup((uint256),bool)",
+        "singleTup(bytes,(bytes),bool)",
+        "singleTup((uint256,bool),bool)",
+        "singleTup((uint256,bool),bytes)",
+        "singleTup(bytes,(uint256),bool)",
+        "singleTup(bytes,(bytes),bool)",
+        "singleTup(bool,(uint256,bytes),bytes)",
+        "singleTup((uint256,uint256)[],bool)",
+        "singleTup((bytes)[],bool)",
+        "singleTup((bytes)[1],bool)",
+        "multiTup((uint256,uint256)[],(bool))",
+        "multiTup((uint256,uint256)[2],(bool))",
+        "multiTup((uint256)[2],(bool)[])",
+        "multiTup((uint256)[2],(bool)[2])",
+        "multiTup((uint256)[],(bool))",
+        "multiTup((uint256)[],(bool)[2])",
+        "multiTup((uint256,uint256)[],(bool)[])",
+        "multiTup((uint256,uint256)[2],(bool)[])",
+        "multiTup((uint256)[2][2],(bool)[2][2])",
+        "multiTup((uint256)[2][],(bool)[2][])",
+        "multiTup((uint256)[2][],(bool)[][])",
+        "multiTup((uint256)[][],(bool)[2][])",
+        "multiTup((uint256)[][],(bool)[][])",
+        "multiTup((uint256)[][],(bool)[2][2])",
+        "multiTup((uint256)[2][2],(bool)[][])",
+        "nestedTup(uint256,(bytes)[1],bool)",
+        "nestedTup((uint256,(bool,address),bool))",
+        "nestedTup((uint256,(bool,bytes),bool))",
+        "nestedTup(bool,(uint256,(bool,bytes),bool))",
+        "nestedTup(bytes,(uint256,(bool,bytes),bool))",
+        "nestedTup(bytes,(uint256,(bool,bytes)[],bool))",
+        "nestedTup(bool,(uint256,(bool,bytes),bool)[])",
+        "nestedTup(bytes,(uint256,(bool,bytes)[][],bool)[])",
+        "nestedTup(bytes,(uint256,(bool)[2],bool))",
+        "nestedTup((uint256,(bytes[])[2],uint256))",
+        "nestedTup((uint256,(bytes[2])[2],uint256))",
+        "nestedTup((uint256,(bytes[2])[],uint256))",
+        "nestedTup((uint256,(bytes[])[],uint256))",
+        "nestedTup((uint256,(bytes)[2],bool))",
+        "nestedTup((bytes,(bytes)[2],bool))",
+        "nestedTup(bytes,(uint256,(bool)[2],bool))",
+        "nestedTup(bytes,(uint256,(bytes)[2],bool))"
+        // ---
+        // Extreme edge cases that do not currently decode
+        // ---
+        // "nestedTup(((bytes)[1],bool))", // does not decode
+        // "nestedTup(((bytes)[2],bool))", // does not decode
+        // "nestedTup(bytes,(uint256,(bool,bytes)[2],bool))", // does not decode
+        // "nestedTup(bytes,(uint256,(bool,bytes)[2],bool))", // does not decode
+        // "nestedTup(bytes,(uint256,(bool,bytes)[2],bool)[])", // does not decode
+        // "nestedTup(bytes,(uint256,(bool,bytes)[2],bool)[2])", // does not decode
+        // "nestedTup(bytes,(uint256,(bool,bytes)[][],bool)[2][])", // too large
+      ]
+    }
+  }
+}

--- a/test/testSigs.ts
+++ b/test/testSigs.ts
@@ -6,7 +6,7 @@ import { ecsign, privateToAddress } from 'ethereumjs-util';
 import { keccak256 } from 'js-sha3';
 import { question } from 'readline-sync';
 import seedrandom from 'seedrandom';
-import { HARDENED_OFFSET } from '../src/constants';
+import { HARDENED_OFFSET, responseMessages } from '../src/constants';
 import { randomBytes } from '../src/util'
 import helpers from './testUtil/helpers';
 
@@ -416,6 +416,39 @@ describe('Setup Test', () => {
       addr8.toLowerCase(),
       'Incorrect address 8 fetched.'
     );
+  })
+
+  it('Should test that wrongWallet retry works', async () => {
+    continueTests = false;
+    question(
+      'Please switch to a different SafeCard. Press enter to continue.'
+    );
+    try {
+      // Should get wrong wallet on the first attempt
+      await client.sign(txReq);
+    } catch (err) {
+      expect(err).to.equal(
+        responseMessages[responseCodes.RESP_ERR_WRONG_WALLET], 
+        'Wrong wallet expected.'
+      );
+      // Make another request. This one should pass because the wallet
+      // has not changed relative to the last request
+      await client.sign(txReq);
+      // Now ask the user to switch back and clean up
+      question(
+        'Please switch back to your original SafeCard. Press enter to continue.'
+      );
+      try {
+        await client.sign(txReq);
+      } catch (err) {
+        expect(err).to.equal(
+          responseMessages[responseCodes.RESP_ERR_WRONG_WALLET], 
+          'Wrong wallet expected.'
+        );
+        await client.sign(txReq);
+        continueTests = true;
+      }
+    }
   })
 })
 


### PR DESCRIPTION
- [x] Adds mechanism to pack information about how to decode calldata inside the signing request itself. Can only be used with general signing. First use case is EVM ABI data, as this allows decoding of calldata without having to save ABI definitions ahead of time. One important caveat is that for EVM ABIs, the param names are unverified, so those can still be committed to the Lattice.
- [ ] Changes how ABI data is sent to the Lattice if firmware is >v0.15.0
- [ ] Changes ABI CRUD API to handle how ABI data is now just an RLP serialized array