### PR TITLE
Revert "Bumps to v1.1.2 because the v1.1.1 build files were cached"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gridplus-sdk",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gridplus-sdk",
-      "version": "1.1.2",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/common": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
Reverts GridPlus/gridplus-sdk#323