### PR TITLE
Fixes slightly misaligned constant for ETH data size

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -399,12 +399,13 @@ function getFwVersionConst(v) {
   // --- 0.11.X ---
   // V0.11.0 allows new ETH transaction types
   if (!legacy && gte(v, [0, 11, 0])) {
-    c.allowedEthTxTypesVersion = 1;
     c.allowedEthTxTypes = [
       1, // eip2930
       2, // eip1559
     ];
-    c.totalExtraEthTxDataSz = 10;
+    // This version added extra data fields to the ETH tx
+    c.ethMaxDataSz -= 10;
+    c.ethMaxMsgSz = c.ethMaxDataSz;
   }
   // V0.11.2 changed how messages are displayed. For personal_sign messages
   // we now write the header (`Signer: <path>`) into the main body of the screen.

--- a/src/ethereum.ts
+++ b/src/ethereum.ts
@@ -83,7 +83,7 @@ const buildEthereumTxRequest = function (data) {
       prehashAllowed,
     } = fwConstants;
     const EXTRA_DATA_ALLOWED = extraDataFrameSz > 0 && extraDataMaxFrames > 0;
-    let MAX_BASE_DATA_SZ = fwConstants.ethMaxDataSz;
+    const MAX_BASE_DATA_SZ = fwConstants.ethMaxDataSz;
     const VAR_PATH_SZ = fwConstants.varAddrPathSzAllowed;
     // Sanity checks:
     // There are a handful of named chains we allow the user to reference (`chainIds`)
@@ -91,8 +91,9 @@ const buildEthereumTxRequest = function (data) {
     if (
       typeof chainId !== 'number' &&
       isValidChainIdHexNumStr(chainId) === false
-    )
+    ) {
       chainId = chainIds[chainId];
+    }
     // If this was not a custom chainID and we cannot find the name of it, exit
     if (!chainId) throw new Error('Unsupported chain ID or name');
     // Sanity check on signePath
@@ -208,13 +209,6 @@ const buildEthereumTxRequest = function (data) {
     // 2. BUILD THE LATTICE REQUEST PAYLOAD
     //--------------
     const ETH_TX_NON_DATA_SZ = 122; // Accounts for metadata and non-data params
-    let ETH_TX_EXTRA_FIELDS_SZ = 0; // Accounts for newer ETH tx types (e.g. eip1559)
-    if (fwConstants.allowedEthTxTypesVersion === 1) {
-      // eip1559 and eip2930
-      // Add extra params and shrink the data region (extraData blocks are unaffected)
-      ETH_TX_EXTRA_FIELDS_SZ = fwConstants.totalExtraEthTxDataSz;
-      MAX_BASE_DATA_SZ -= ETH_TX_EXTRA_FIELDS_SZ;
-    }
     const txReqPayload = Buffer.alloc(MAX_BASE_DATA_SZ + ETH_TX_NON_DATA_SZ);
     let off = 0;
     // 1. EIP155 switch and chainID
@@ -267,8 +261,7 @@ const buildEthereumTxRequest = function (data) {
 
     // Extra Tx data comes before `data` in the struct
     let PREHASH_UNSUPPORTED = false;
-    if (fwConstants.allowedEthTxTypesVersion === 1) {
-      const extraEthTxDataSz = fwConstants.totalExtraEthTxDataSz || 0;
+    if (fwConstants.allowedEthTxTypes) {
       // Some types may not be supported by firmware, so we will need to prehash
       if (PREHASH_FROM_ACCESS_LIST) {
         PREHASH_UNSUPPORTED = true;
@@ -285,13 +278,13 @@ const buildEthereumTxRequest = function (data) {
           txReqPayload,
           off + (8 - maxPriorityFeePerGasBytes.length)
         );
-        off += 8;
+        off += 8; // Skip EIP1559 params
       } else if (isEip2930) {
         txReqPayload.writeUInt8(1, off);
         off += 1; // Eip2930 type enum value
-        off += extraEthTxDataSz - 2; // Skip EIP1559 params
+        off += 8; // Skip EIP1559 params
       } else {
-        off += extraEthTxDataSz - 1; // Skip EIP1559 and EIP2930 params
+        off += 9; // Skip EIP1559 and EIP2930 params
       }
     }
 

--- a/test/testEth.ts
+++ b/test/testEth.ts
@@ -385,10 +385,8 @@ if (!process.env.skip) {
       // 8 bytes for the id itself and 1 byte for chainIdSz. This data is serialized into the request payload.
       let chainIdSz = 9;
       const fwConstants = getFwVersionConst(client.fwVersion);
-      const metadataSz = fwConstants.totalExtraEthTxDataSz || 0;
       const maxDataSz =
-        fwConstants.ethMaxDataSz -
-        metadataSz +
+        fwConstants.ethMaxDataSz +
         fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
       txData.data = `0x${randomBytes(maxDataSz - chainIdSz).toString('hex')}`;
       await testTxPass(buildTxReq(txData, chainId));

--- a/test/testEthMsg.ts
+++ b/test/testEthMsg.ts
@@ -137,13 +137,11 @@ describe('Test ETH personalSign', function () {
   it('Msg: sign_personal boundary conditions and auto-rejected requests', async () => {
     const protocol = 'signPersonal';
     const fwConstants = getFwVersionConst(client.fwVersion);
-    const metadataSz = fwConstants.totalExtraEthTxDataSz || 0;
     // `personal_sign` requests have a max size smaller than other requests because a header
     // is displayed in the text region of the screen. The size of this is captured
     // by `fwConstants.personalSignHeaderSz`.
     const maxMsgSz =
-      fwConstants.ethMaxMsgSz -
-      metadataSz -
+      fwConstants.ethMaxMsgSz +
       fwConstants.personalSignHeaderSz +
       fwConstants.extraDataMaxFrames * fwConstants.extraDataFrameSz;
     const maxValid = `0x${randomBytes(maxMsgSz).toString('hex')}`;


### PR DESCRIPTION
We added some extradata params to a previous version of Lattice firmware
and never fully accounted for them here. This PR fixes that issue by
simply changing max data size constant