### PR TITLE
util - lazy instantiate ec for init perf boost

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -13,7 +13,7 @@ import {
 } from './constants';
 const { COINS, PURPOSES } = BIP_CONSTANTS;
 const EC = elliptic.ec;
-const ec = new EC('p256');
+let ec;
 //--------------------------------------------------
 // LATTICE UTILS
 //--------------------------------------------------
@@ -216,10 +216,12 @@ export const parseDER = function(sigBuf) {
 }
 
 export const getP256KeyPair = function(priv) {
+  if (ec === undefined) ec = new EC('p256');
   return ec.keyFromPrivate(priv, 'hex');
 }
 
 export const getP256KeyPairFromPub = function(pub) {
+  if (ec === undefined) ec = new EC('p256');
   return ec.keyFromPublic(pub, 'hex');
 }
 


### PR DESCRIPTION
in the browser with lavamoat, module initialization times went 4150ms -> 86ms for this module when this change was made

the 4s initialization of this module is by far the largest in metamask background context

![image](https://user-images.githubusercontent.com/1474978/165904494-a7cc9acf-c0de-4408-89c9-55d6299b65e3.png)

i believe the underlying performance issue comes from a bug in v8 where there is a large slowdown when setting a field on an instance of a TypedArray subclass that has been `Object.freeze`'d as in SES lockdown