### PR TITLE
Fixes edge case in general signing related to decoder data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gridplus-sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gridplus-sdk",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/common": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
We shouldn't allow packing of decoder data if it expands the request
size beyond the firmware buffer size. This will result in the calldata
getting included in the pre-hash, which will result in failed txs.