### PR TITLE
Adds `v` component to `EVM` signing requests for backwards compatability

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1585,12 +1585,7 @@ export class Client {
       };
     } else {
       // Generic signing request
-      return parseGenericSigningResponse(
-        res,
-        off,
-        req.curveType,
-        req.omitPubkey,
-      );
+      return parseGenericSigningResponse(res, off, req);
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -366,7 +366,7 @@ export const getV = function (tx, resp) {
         chainId = null;
       } else {
         // Otherwise the `v` param is the `chainId`
-        chainId = new BN(legacyTxArray[6]);
+        chainId = new BN(legacyTxArray[6] as Uint8Array);
       }
       // Legacy tx = type 0
       type = 0;
@@ -374,6 +374,7 @@ export const getV = function (tx, resp) {
       // This is likely a typed transaction
       try {
         const txObj = EthTxFactory.fromSerializedData(tx);
+        //@ts-expect-error -- Accessing private property
         type = txObj._type;
       } catch (err) {
         // If we can't RLP decode and can't hydrate an @ethereumjs/tx object,

--- a/test/signing/evm.ts
+++ b/test/signing/evm.ts
@@ -81,7 +81,6 @@ describe('Start EVM signing tests', () => {
 });
 
 describe('[EVM] Test transactions', () => {
-
   describe('EIP1559', () => {
     beforeEach(() => {
       test.expect(test.continue).to.equal(true, 'Error in previous test.');
@@ -178,7 +177,7 @@ describe('[EVM] Test transactions', () => {
       await run(req);
     });
   });
-
+  
   describe('Legacy (Non-EIP155)', () => {
     beforeEach(() => {
       test.expect(test.continue).to.equal(true, 'Error in previous test.');
@@ -202,7 +201,7 @@ describe('[EVM] Test transactions', () => {
       await run(req);
     });
   });
-
+  
   describe('Boundary tests', () => {
     beforeEach(() => {
       test.expect(test.continue).to.equal(true, 'Error in previous test.');
@@ -874,7 +873,7 @@ async function run (
     // Get params from Lattice sig
     const latticeR = Buffer.from(resp.sig.r);
     const latticeS = Buffer.from(resp.sig.s);
-    const latticeV = test.helpers.getV(tx, resp);
+    const latticeV = new BN(resp.sig.v); 
     // Strip off leading zeros to do an exact componenet check.
     // We will still validate the original lattice sig in a tx.
     const rToCheck =
@@ -893,8 +892,8 @@ async function run (
       .expect(sToCheck.equals(refS))
       .to.equal(true, 'Signature S component does not match reference');
     test
-      .expect(new BN(latticeV).eq(refV))
-      .to.equal(true, 'Signature V component does not match reference');
+      .expect(latticeV.toString())
+      .to.equal(refV.toString(), 'Signature V component does not match reference');
     // One more check -- create a new tx with the signatre params and verify it
     const signedTxData = JSON.parse(JSON.stringify(txData));
     signedTxData.v = latticeV;


### PR DESCRIPTION
With the legacy path, requesters expect a `v` value returned when making
an EVM signature. This was possible with the exported `getV` util but
this was not integrated into the signing pathway and it had some shortcomings
(i.e. input had to be an @ethereumjs/tx obect), so it has now been spliced
into the main signing pathway.
NOTE: `v` is a `Buffer` type as with the legacy signing path, but we should
move away from this and into a more standard `bn.js` number type in a future
major version bump