### PR TITLE
Adds sorting to fourByte results

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -438,7 +438,7 @@ export async function fetchCalldataDecoder (_data: Uint8Array | string, to: stri
       Buffer.from(_data.slice(2), 'hex') :
       //@ts-expect-error - Buffer doesn't recognize Uint8Array type properly
       Buffer.from(_data, 'hex');
-      
+
     if (data.length < 4) {
       throw new Error('Data must contain at least 4 bytes of data to define the selector')
     }
@@ -489,7 +489,11 @@ export async function fetchCalldataDecoder (_data: Uint8Array | string, to: stri
       if (fourByteResults.length > 1) {
         console.warn('WARNING: There are multiple results. Using the first one.');
       }
-      const canonicalName = fourByteResults[0]?.text_signature;
+      const canonicalName = fourByteResults.sort((a, b) => {
+        const aTime = new Date(a.created_at).getTime();
+        const bTime = new Date(b.created_at).getTime();
+        return aTime - bTime;
+      })[0]?.text_signature;
       return {
         def: Calldata.EVM.parsers.parseCanonicalName(selector, canonicalName),
         abi: fourByteResults


### PR DESCRIPTION
Fixes #410 

```sh
      ✔ (Etherscan + 4byte #0) 0xeee0752109c6d31038bab6c2b0a3e3857e8bffb9c229de71f0196fda6fb28a5e (10377ms)
      ✔ (Etherscan + 4byte #1) 0xa6173b4890303e12ca1b195ea4a04d8891b0d83768b734d2ecdb9c6dd9d828c4 (7707ms)
      ✔ (Etherscan + 4byte #2) 0xee9710119c13dba6fe2de240ef1e24a2489e98d9c7dd5881e2901056764ee234 (7642ms)
      ✔ (Etherscan + 4byte #3) 0xc33308ca105630b99a0c24ddde4f4506aa4115ec6f1a25f1138f3bd8cfa32b49 (7658ms)
      ✔ (Etherscan + 4byte #4) 0xe15e6205c6696d444fc426468defdf08e89a0f5b3b8a17c68428f7aeefd53ca1 (11965ms)
```