### PR TITLE
Reduces perceived severity of decoder error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gridplus-sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gridplus-sdk",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/common": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "build": "NODE_ENV=production tsc -p tsconfig.json",

--- a/src/util.ts
+++ b/src/util.ts
@@ -530,8 +530,7 @@ export async function fetchCalldataDecoder (_data: Uint8Array | string, to: stri
     throw new Error('Could not find selector in calldata from 4byte')
   }
   catch (err) {
-    err.message = `Fetching calldata failed \n ${err.message}`
-    console.warn(err)
+    console.warn(`Fetching calldata failed: ${err.message}`)
     return { def: null, abi: null }
   }
 }


### PR DESCRIPTION
- Logs just the `Fetching calldata failed` and the error message instead of logging the `Error` object. 
- Bumps to `v2.1.1`
- Fixes #429 