### PR TITLE
Adds seed as arg to EVM signing test util

### DIFF
--- a/src/__test__/e2e/signing/evm.test.ts
+++ b/src/__test__/e2e/signing/evm.test.ts
@@ -19,11 +19,13 @@ import { fetchCalldataDecoder, randomBytes } from '../../../util';
 import { buildEncDefs, buildEvmReq, DEFAULT_SIGNER, getNumIter } from '../../utils/builders';
 import { getEtherscanKey } from '../../utils/getters';
 import { runEvm } from '../../utils/runners';
+import { initializeSeed } from '../../utils/initializeClient';
 
 const globalVectors = jsonc.parse(
   readFileSync(`${process.cwd()}/src/__test__/vectors.jsonc`).toString(),
 );
 const vectors = globalVectors.evm.calldata;
+let CURRENT_SEED = null;
 
 //---------------------------------------
 // STATE DATA
@@ -46,9 +48,10 @@ export const runEvmTests = ({ client }: { client: Client }) => {
       return runEvm(
         evmReq,
         client,
+        CURRENT_SEED,
         bypassSetPayload,
         shouldFail,
-        useLegacySigning,
+        useLegacySigning
       ).catch((err) => {
         if (err.responseCode === 128) {
           err.message =
@@ -58,6 +61,10 @@ export const runEvmTests = ({ client }: { client: Client }) => {
         throw err;
       });
     };
+
+    it('Should get the current wallet seed',  async () => {
+      CURRENT_SEED = await initializeSeed(client);
+    })
 
     describe('[EVM] Test transactions', () => {
       describe('EIP1559', () => {

--- a/src/__test__/utils/runners.ts
+++ b/src/__test__/utils/runners.ts
@@ -42,6 +42,7 @@ export async function runGeneric (request: SignRequestParams, client: Client) {
 export async function runEvm (
   req: any,
   client: Client,
+  seed: any,
   bypassSetPayload = false,
   shouldFail = false,
   useLegacySigning = false,
@@ -87,7 +88,9 @@ export async function runEvm (
     req.data.hashType = Constants.SIGNING.HASHES.KECCAK256;
     req.data.encodingType = Constants.SIGNING.ENCODINGS.EVM;
   }
-  const seed = await initializeSeed(client)
+  if (!seed) {
+    seed = await initializeSeed(client)
+  }
   validateGenericSig(seed, resp.sig, payloadBuf, req.data);
   // Sign the original tx and compare
   const { priv } = deriveSECP256K1Key(req.data.signerPath, seed);


### PR DESCRIPTION
This will avoid an unnecessary call being made for each individual signing request. It replaces that with a single call at the beginning of the signing test script.
Fixes #465