### PR TITLE
Moves @ethersproject/abi to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@ethereumjs/common": "2.4.0",
         "@ethereumjs/tx": "3.3.0",
+        "@ethersproject/abi": "^5.5.0",
         "aes-js": "^3.1.1",
         "bech32": "^2.0.0",
         "bignumber.js": "^9.0.1",
@@ -33,7 +34,6 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-typescript": "^7.17.12",
         "@chainsafe/bls-keystore": "^3.0.0",
-        "@ethersproject/abi": "^5.5.0",
         "@ethersproject/transactions": "^5.5.0",
         "@noble/bls12-381": "^1.3.0",
         "@solana/web3.js": "^1.34.0",
@@ -1827,7 +1827,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
       "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1854,7 +1853,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
       "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1879,7 +1877,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
       "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1902,7 +1899,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
       "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1925,7 +1921,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
       "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1944,7 +1939,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
       "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1965,7 +1959,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
       "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1984,7 +1977,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
       "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2003,7 +1995,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
       "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2029,7 +2020,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
       "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2049,7 +2039,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
       "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2065,7 +2054,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
       "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2084,7 +2072,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
       "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2103,7 +2090,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
       "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2144,7 +2130,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
       "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2168,7 +2153,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
       "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2189,7 +2173,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
       "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2216,7 +2199,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
       "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -11108,7 +11090,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
       "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -11125,7 +11106,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
       "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -11140,7 +11120,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
       "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -11153,7 +11132,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
       "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -11166,7 +11144,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
       "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1"
       }
@@ -11175,7 +11152,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
       "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -11186,7 +11162,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
       "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -11195,7 +11170,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
       "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2"
       }
@@ -11204,7 +11178,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
       "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -11220,7 +11193,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
       "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "js-sha3": "0.8.0"
@@ -11229,14 +11201,12 @@
     "@ethersproject/logger": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
-      "dev": true
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
     },
     "@ethersproject/networks": {
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
       "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -11245,7 +11215,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
       "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -11254,7 +11223,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
       "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -11275,7 +11243,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
       "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -11289,7 +11256,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
       "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/constants": "^5.6.1",
@@ -11300,7 +11266,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
       "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -11317,7 +11282,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
       "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
-      "dev": true,
       "requires": {
         "@ethersproject/base64": "^5.6.1",
         "@ethersproject/bytes": "^5.6.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@ethereumjs/common": "2.4.0",
     "@ethereumjs/tx": "3.3.0",
+    "@ethersproject/abi": "^5.5.0",
     "aes-js": "^3.1.1",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.0.1",
@@ -67,7 +68,6 @@
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-typescript": "^7.17.12",
     "@chainsafe/bls-keystore": "^3.0.0",
-    "@ethersproject/abi": "^5.5.0",
     "@ethersproject/transactions": "^5.5.0",
     "@noble/bls12-381": "^1.3.0",
     "@solana/web3.js": "^1.34.0",


### PR DESCRIPTION
[`getNestedCalldata()`](https://github.com/GridPlus/gridplus-sdk/blob/dd6c1e0aa213b967c1941b71cc60889ca4c533db/src/calldata/evm.ts#L76) uses this dependency in production builds, so it needs to be moved into `dependencies` from `devDependencies`