### PR TITLE
Replaces `@chainsafe/ssz` with `lattice-eth2-utils` as devDepenency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "gridplus-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gridplus-sdk",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@chainsafe/ssz": "^0.9.2",
         "@ethereumjs/common": "2.4.0",
         "@ethereumjs/tx": "3.3.0",
         "@ethersproject/abi": "^5.5.0",
@@ -60,6 +59,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "ethereumjs-util": "^7.1.4",
         "jsonc": "^2.0.0",
+        "lattice-eth2-utils": "^0.1.0",
         "lodash": ">=4.17.21",
         "minimist": ">=0.2.1",
         "msw": "^0.42.0",
@@ -1719,7 +1719,8 @@
     "node_modules/@chainsafe/as-sha256": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
-      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "dev": true
     },
     "node_modules/@chainsafe/bls-keystore": {
       "version": "3.0.0",
@@ -1768,6 +1769,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
       "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "dev": true,
       "dependencies": {
         "@chainsafe/as-sha256": "^0.3.1"
       }
@@ -1776,6 +1778,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.2.tgz",
       "integrity": "sha512-r3bKiGMF7EZlsgXTyyzQbS+GJTj6MvTlY3Ms1byFZLL1H9Maht8muE2LkF3pS1zU9KY4tiJeQd+KABdhyfB9Ag==",
+      "dev": true,
       "dependencies": {
         "@chainsafe/as-sha256": "^0.3.1",
         "@chainsafe/persistent-merkle-tree": "^0.4.2",
@@ -4010,6 +4013,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
       "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -5904,6 +5908,34 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/gridplus-sdk": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/gridplus-sdk/-/gridplus-sdk-2.4.0.tgz",
+      "integrity": "sha512-9yYE5gUuYWl03X3gmU0ETkT3XS69MYOex2t1OOpwYBSWUWWycWa51RJz8i3nTWAB0JbQLC/Ix5uKfuHJ2xxokg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethereumjs/common": "2.4.0",
+        "@ethereumjs/tx": "3.3.0",
+        "@ethersproject/abi": "^5.5.0",
+        "aes-js": "^3.1.1",
+        "bech32": "^2.0.0",
+        "bignumber.js": "^9.0.1",
+        "bitwise": "^2.0.4",
+        "borc": "^2.1.2",
+        "bs58check": "^2.1.2",
+        "buffer": "^5.6.0",
+        "crc-32": "^1.2.0",
+        "elliptic": "6.5.4",
+        "eth-eip712-util-browser": "^0.0.3",
+        "hash.js": "^1.1.7",
+        "js-sha3": "^0.8.0",
+        "rlp": "^3.0.0",
+        "secp256k1": "4.0.2",
+        "uuid": "^9.0.0"
+      }
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7075,6 +7107,30 @@
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
+    },
+    "node_modules/lattice-eth2-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lattice-eth2-utils/-/lattice-eth2-utils-0.1.0.tgz",
+      "integrity": "sha512-Pwb/YfZKjQv2mJ0MvDzJ2IxzRiCOvvAkwsK4n5m57ZDpohYEPZij9VIASXmTYNVKtkIDfg4czQhgiTw6PenIYA==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/ssz": "^0.9.2",
+        "@noble/hashes": "^1.1.4",
+        "bn.js": "^5.2.1",
+        "gridplus-sdk": "^2.4.0"
+      }
+    },
+    "node_modules/lattice-eth2-utils/node_modules/@noble/hashes": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
+      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -11033,7 +11089,8 @@
     "@chainsafe/as-sha256": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
-      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "dev": true
     },
     "@chainsafe/bls-keystore": {
       "version": "3.0.0",
@@ -11075,6 +11132,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
       "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "dev": true,
       "requires": {
         "@chainsafe/as-sha256": "^0.3.1"
       }
@@ -11083,6 +11141,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.2.tgz",
       "integrity": "sha512-r3bKiGMF7EZlsgXTyyzQbS+GJTj6MvTlY3Ms1byFZLL1H9Maht8muE2LkF3pS1zU9KY4tiJeQd+KABdhyfB9Ag==",
+      "dev": true,
       "requires": {
         "@chainsafe/as-sha256": "^0.3.1",
         "@chainsafe/persistent-merkle-tree": "^0.4.2",
@@ -12728,7 +12787,8 @@
     "case": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
-      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ=="
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -14089,6 +14149,33 @@
       "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
       "dev": true
     },
+    "gridplus-sdk": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/gridplus-sdk/-/gridplus-sdk-2.4.0.tgz",
+      "integrity": "sha512-9yYE5gUuYWl03X3gmU0ETkT3XS69MYOex2t1OOpwYBSWUWWycWa51RJz8i3nTWAB0JbQLC/Ix5uKfuHJ2xxokg==",
+      "dev": true,
+      "requires": {
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethereumjs/common": "2.4.0",
+        "@ethereumjs/tx": "3.3.0",
+        "@ethersproject/abi": "^5.5.0",
+        "aes-js": "^3.1.1",
+        "bech32": "^2.0.0",
+        "bignumber.js": "^9.0.1",
+        "bitwise": "^2.0.4",
+        "borc": "^2.1.2",
+        "bs58check": "^2.1.2",
+        "buffer": "^5.6.0",
+        "crc-32": "^1.2.0",
+        "elliptic": "6.5.4",
+        "eth-eip712-util-browser": "^0.0.3",
+        "hash.js": "^1.1.7",
+        "js-sha3": "^0.8.0",
+        "rlp": "^3.0.0",
+        "secp256k1": "4.0.2",
+        "uuid": "^9.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -14976,6 +15063,26 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "lattice-eth2-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lattice-eth2-utils/-/lattice-eth2-utils-0.1.0.tgz",
+      "integrity": "sha512-Pwb/YfZKjQv2mJ0MvDzJ2IxzRiCOvvAkwsK4n5m57ZDpohYEPZij9VIASXmTYNVKtkIDfg4czQhgiTw6PenIYA==",
+      "dev": true,
+      "requires": {
+        "@chainsafe/ssz": "^0.9.2",
+        "@noble/hashes": "^1.1.4",
+        "bn.js": "^5.2.1",
+        "gridplus-sdk": "^2.4.0"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
+          "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA==",
+          "dev": true
+        }
       }
     },
     "levn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "build": "NODE_ENV=production tsc -p tsconfig.json",
@@ -44,7 +44,6 @@
     "url": "https://github.com/GridPlus/gridplus-sdk.git"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.9.2",
     "@ethereumjs/common": "2.4.0",
     "@ethereumjs/tx": "3.3.0",
     "@ethersproject/abi": "^5.5.0",
@@ -94,6 +93,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "ethereumjs-util": "^7.1.4",
     "jsonc": "^2.0.0",
+    "lattice-eth2-utils": "^0.1.0",
     "lodash": ">=4.17.21",
     "minimist": ">=0.2.1",
     "msw": "^0.42.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
 // Static utility functions
-import { ByteVectorType, ContainerType, UintNumberType, } from '@chainsafe/ssz';
 import { Capability, TransactionFactory as EthTxFactory } from '@ethereumjs/tx';
 import aes from 'aes-js';
 import BigNum from 'bignumber.js';
@@ -20,7 +19,6 @@ import {
   HARDENED_OFFSET,
   responseCodes,
   responseMsgs,
-  PUBLIC,
   VERSION_BYTE,
   EXTERNAL_NETWORKS_BY_CHAIN_ID_URL,
 } from './constants';
@@ -565,75 +563,6 @@ async function replaceNestedDefs (possNestedDefs) {
   return nestedDefs;
 }
 
-/**
- * Generate domain data for an ETH deposit.
- * This is constructed out of a domain type (DEPOSIT) and a ForkData root.
- * 
- * ForkData definition:
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#forkdata
- * 
- * @param forkVersion - A four byte version constant (default=00000000)
- * @return 32 byte Buffer containing domain data
- */
-function getEthDepositDomain(
-  forkVersion: Buffer,
-  validatorsRoot: Buffer,
-): Buffer {
-  if (forkVersion.length !== 4) {
-    throw new Error('`forkVersion` must be a 4-byte Buffer.');
-  } else if (validatorsRoot.length !== 32) {
-    throw new Error('`validatorsRoot` must be a 32-byte Buffer.');
-  }
-  const forkDataType = new ContainerType({
-    current_version: new ByteVectorType(4),
-    genesis_validators_root: new ByteVectorType(32),
-  });
-  const forkDataRoot = Buffer.from(forkDataType.hashTreeRoot({
-    current_version: forkVersion,
-    genesis_validators_root: validatorsRoot,
-  }));
-  // Construct the domain, see:
-  // https://github.com/ethereum/staking-deposit-cli/blob/
-  // e2a7c942408f7fc446b889097f176238e4a10a76/staking_deposit/utils/ssz.py#L42
-  const depositDomain = Buffer.alloc(32);
-  PUBLIC.ETH_CONSENSUS_SPEC.DOMAINS.DEPOSIT.copy(depositDomain, 0);
-  forkDataRoot.slice(0, 28).copy(depositDomain, 4);
-  return depositDomain;
-}
-
-//--------------------------------------------------
-// ETH DEPOSIT UTILS
-//--------------------------------------------------
-/**
- * Get the withdrawal credentials given a key.
- * There are currently two supported types of withdrawal:
- * - 0x00: BLS key used to withdraw
- * - 0x11: ETH1 key used to withdraw
- * 
- * @param withdrawalKey - Buffer containing either BLS withdrawal pubkey (48 bytes)
- *                        or Ethereum address (20 bytes)
- * @return 32-byte Buffer containing withdrawal credentials
- */
-function getEthDepositWithdrawalCredentials(
-  withdrawalKey: Buffer, // BLS pubkey of mapped withdrawal key OR ETH1 address
-): Buffer {
-  const creds = Buffer.alloc(32);
-  const keyBuf =  ensureHexBuffer(withdrawalKey);
-  if (keyBuf.length === 48) {
-    // BLS key - must be hashed first
-    creds[0] = 0;
-    const h = sha256().update(keyBuf).digest('hex');
-    Buffer.from(h, 'hex').slice(1).copy(creds, 1);
-  } else if (keyBuf.length === 20) {
-    // ETH1 key - added raw to buffer, left padded
-    creds[0] = 1;
-    keyBuf.copy(creds, 12);
-  } else {
-    throw new Error('`withdrawalKey` must be 48 byte BLS pubkey or Ethereum address.');
-  }
-  return creds;
-}
-
 //--------------------------------------------------
 //--------------------------------------------------
 // EXTERNAL UTILS
@@ -726,150 +655,6 @@ export const generateAppSecret = (
 };
 
 /**
- * Generate ETH deposit data for a given validator.
- * This requires a secure connection with a Lattice via `client`.
- * A signing request will be made on the signing root, which is needed
- * before deposit data can be formed.
- * 
- * @param client - Instance of GridPlus SDK, which is already connected/paired to a target Lattice.
- * @param depositPath - Array with up to five u32 indices representing BIP39 path.
- * @param req - Instance of `EthDepositDataReq` containing params to build the deposit data.
- * @return JSON string containing deposit data for this validator.
- */
-export async function getEthDepositData(
-  client,
-  depositPath: number[],
-  params: EthDepositDataReq
-) : Promise<EthDepositDataResp> {
-  const { 
-    amountGwei=32000000000, 
-    depositCliVersion='2.3.0',
-    info=PUBLIC.ETH_CONSENSUS_SPEC.NETWORKS.MAINNET_GENESIS,
-    withdrawalKey, 
-  } = params;
-  // Sanity checks
-  if (!depositPath || !amountGwei || !info || !depositCliVersion) {
-    throw new Error(
-      'One or more params missing from `req`: `depositPath`, `amountGwei`, `info`, `depositCliVersion`.'
-    );
-  }
-  if (amountGwei < 0 || new BN(amountGwei).gte(new BN(2).pow(new BN(64)))) {
-    throw new Error('`amountGwei` must be >0 and <UINT64_MAX')
-  }
-  const { networkName, forkVersion, validatorsRoot } = info;
-  if (!networkName) {
-    throw new Error('No `info.network` value found.');
-  }
-  if (!forkVersion) {
-    throw new Error('No `info.forkVersion` value found.');
-  } else if (forkVersion.length !== 4) {
-    throw new Error('`info.forkVersion` must be a 4 byte Buffer.')
-  }
-  if (!validatorsRoot) {
-    throw new Error('No `info.validatorsRoot` value found.');
-  } else if (validatorsRoot.length !== 32) {
-    throw new Error('`info.validatorsRoot` must be a 32 byte Buffer.');
-  }
-  // Start building data. Items should be strings. Some can be copied directly.
-  const depositData = {
-    pubkey: null,
-    withdrawal_credentials: null,
-    amount: amountGwei,
-    signature: null,
-    deposit_message_root: null,
-    deposit_data_root: null,
-    fork_version: forkVersion.toString('hex'),
-    network_name: networkName,
-    deposit_cli_version: depositCliVersion,
-  };
-
-  // Get the depositor pubkey
-  const getAddrFlag = PUBLIC.GET_ADDR_FLAGS.BLS12_381_G1_PUB;
-  const depositPubs = await client.getAddresses({ startPath: depositPath, flag: getAddrFlag });
-  const depositKey = depositPubs[0];
-  depositData.pubkey = depositKey.toString('hex');
-
-  // If no withdrawalKey was passed, fetch the BLS one
-  let withdrawalKeyBuf;
-  if (withdrawalKey) {
-    // If a withdrawal key was provided, capture it here
-    withdrawalKeyBuf = ensureHexBuffer(withdrawalKey);
-  } else {
-    // Otherwise we should derive the corresponding withdrawal key.
-    // The withdrawal path is just up one derivation index relative to deposit path.
-    // See: https://eips.ethereum.org/EIPS/eip-2334
-    const withdrawalPath = depositPath.slice(0, depositPath.length-1);
-    const withdrawalPubs = await client.getAddresses({ startPath: withdrawalPath, flag: getAddrFlag});
-    withdrawalKeyBuf = withdrawalPubs[0];
-  }
-  // We can now generate the withdrawal credentials
-  const withdrawalCreds = getEthDepositWithdrawalCredentials(withdrawalKeyBuf);
-  depositData.withdrawal_credentials = withdrawalCreds.toString('hex');
-
-  // Build the message root
-  // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#depositmessage
-  const depositMessageType = new ContainerType({
-    pubkey: new ByteVectorType(48),
-    withdrawal_credentials: new ByteVectorType(32),
-    amount: new UintNumberType(8),
-  });
-  const depositMessageRoot = Buffer.from(depositMessageType.hashTreeRoot({
-    pubkey: depositKey,
-    withdrawal_credentials: withdrawalCreds,
-    amount: amountGwei,
-  }));
-  depositData.deposit_message_root = depositMessageRoot.toString('hex');
-  
-  // Build the signing root
-  // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#compute_signing_root
-  const signingType = new ContainerType({
-    object_root: new ByteVectorType(32),
-    domain: new ByteVectorType(32),
-  });
-  const signingRoot = Buffer.from(signingType.hashTreeRoot({
-    object_root: depositMessageRoot,
-    domain: getEthDepositDomain(forkVersion, validatorsRoot),
-  }));
-  // Sign the root
-  const signReq = {
-    data: {
-      signerPath: depositPath,
-      curveType: PUBLIC.SIGNING.CURVES.BLS12_381_G2,
-      hashType: PUBLIC.SIGNING.HASHES.NONE,
-      encodingType: PUBLIC.SIGNING.ENCODINGS.ETH_DEPOSIT,
-      payload: signingRoot,
-      blsDst: PUBLIC.SIGNING.BLS_DST.BLS_DST_POP,
-    }
-  };
-  const sig = await client.sign(signReq);
-  if (sig.pubkey.toString('hex') !== depositData.pubkey) {
-    throw new Error('Incorrect signer returned. Deposit data generation failed.');
-  }
-  depositData.signature = sig.sig.toString('hex');
-
-  // Build the deposit data root
-  // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#depositdata
-  const depositDataType = new ContainerType({
-    pubkey: new ByteVectorType(48),
-    withdrawal_credentials: new ByteVectorType(32),
-    amount: new UintNumberType(8),
-    signature: new ByteVectorType(96),
-  });
-  const depositDataRoot = Buffer.from(depositDataType.hashTreeRoot({
-    pubkey: depositKey,
-    withdrawal_credentials: withdrawalCreds,
-    amount: amountGwei,
-    signature: sig.sig,
-  }));
-  depositData.deposit_data_root = depositDataRoot.toString('hex');
-
-  return {
-    pubkey: depositData.pubkey,
-    depositData: JSON.stringify(depositData),
-  };
-}
-
-/**
  * Generic signing does not return a `v` value like legacy ETH signing requests did.
  * Get the `v` component of the signature as well as an `initV`
  * parameter, which is what you need to use to re-create an `@ethereumjs/tx`
@@ -954,6 +739,5 @@ export const getV = function (tx, resp) {
 export const EXTERNAL = {
   fetchCalldataDecoder,
   generateAppSecret,
-  getEthDepositData,
   getV,
 }


### PR DESCRIPTION
Unfortunately `@chainsafe/ssz` uses webassembly, which will make this SDK difficult/impossible to import into a chrome extension. Therefore, we have broken out the ETH2 functionality into a separate repo: https://github.com/GridPlus/lattice-eth2-utils It has been added as a dev dependency here and has been replaced in the BLS signing tests.
Closes #500