### PR TITLE
Adds missing case for handling negative signed ints in EIP712 messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gridplus-sdk",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gridplus-sdk",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridplus-sdk",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "build": "NODE_ENV=production tsc -p tsconfig.json",

--- a/src/__test__/e2e/eth.msg.test.ts
+++ b/src/__test__/e2e/eth.msg.test.ts
@@ -273,6 +273,41 @@ describe('ETH Messages', () => {
       await runEthMsg(buildEthMsgReq(msg, 'eip712'), client);
     });
 
+    it('Should test Vertex message', async () => {
+      const msg = {
+        'types': {
+            'EIP712Domain': [
+                {'name': 'name', 'type': 'string'},
+                {'name': 'version', 'type': 'string'},
+                {'name': 'chainId', 'type': 'uint256'},
+                {'name': 'verifyingContract', 'type': 'address'}
+            ],
+            'Order': [
+                {'name': 'sender', 'type': 'bytes32'},
+                {'name': 'priceX18', 'type': 'int128'},
+                {'name': 'amount', 'type': 'int128'},
+                {'name': 'expiration', 'type': 'uint64'},
+                {'name': 'nonce', 'type': 'uint64'},
+            ],
+        },
+        'primaryType': 'Order',
+        'domain': {
+            'name': 'Vertex',
+            'version': '0.0.1',
+            'chainId': '42161',  
+            'verifyingContract': '0xf03f457a30e598d5020164a339727ef40f2b8fbc'
+        },
+        'message': {
+            'sender': '0x841fe4876763357975d60da128d8a54bb045d76a64656661756c740000000000',
+            'priceX18': '28898000000000000000000',
+            'amount': '-10000000000000000',
+            'expiration': '4611687701117784255',
+            'nonce': '1764428860167815857',
+        },
+      };
+      await runEthMsg(buildEthMsgReq(msg, 'eip712'), client);
+    })
+
     it('Should test a large 1inch transaction', async () => {
       const msg = {
         domain: {


### PR DESCRIPTION
These types were not being handled properly before, leading to the sign getting dropped.
Note that this change appears to form messages which are rejected by firmware, so we will need to fix that separately.