### PR TITLE
adds `fetchAddress`

### DIFF
--- a/src/__test__/e2e/api.test.ts
+++ b/src/__test__/e2e/api.test.ts
@@ -5,6 +5,7 @@ import { question } from 'readline-sync';
 import { encode } from 'rlp';
 import {
   fetchActiveWallets,
+  fetchAddress,
   fetchAddresses,
   pair,
   signBtcLegacyTx,
@@ -156,14 +157,19 @@ describe('API', () => {
       expect(addresses).toHaveLength(10);
     });
 
+    test('fetchAddress', async () => {
+      const address = await fetchAddress();
+      expect(address).toBeTruthy();
+    });
+
     test('fetchLedgerLiveAddresses', async () => {
       const addresses = await fetchLedgerLiveAddresses();
       expect(addresses).toHaveLength(10);
     });
   });
 
-  describe('fetchActiveWallet', () => {
-    test('fetchActiveWallet', async () => {
+  describe('fetchActiveWallets', () => {
+    test('fetchActiveWallets', async () => {
       const wallet = await fetchActiveWallets();
       expect(wallet).toBeTruthy();
     });

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -24,6 +24,24 @@ export const fetchAddresses = async (
   );
 };
 
+/**
+ * Fetches a single address from the device.
+ *
+ * @note By default, this function fetches m/44'/60'/0'/0/0
+ * @param path - either the index of ETH signing path or the derivation path to fetch
+ */
+export const fetchAddress = async (
+  path: number | WalletPath = 0,
+): Promise<string> => {
+  return fetchAddresses({
+    startPath:
+      typeof path === 'number'
+        ? getStartPath(DEFAULT_ETH_DERIVATION, path)
+        : path,
+    n: 1,
+  }).then((addrs) => addrs[0]);
+};
+
 export const fetchBtcLegacyAddresses = async (
   n = MAX_ADDR,
   startPathIndex?: number,


### PR DESCRIPTION
example:

```ts
const address = await fetchAddress()
// returns the m/44'/60'/0'/0/0 address from the active wallet

const address = await fetchAddress(10)
// returns the m/44'/60'/0'/0/10 address from the wallet

const address = await fetchAddress([HARDENED_OFFSET + 84, HARDENED_OFFSET, HARDENED_OFFSET, 0, 0])
// returns the m/84'/0'/0'/0'/0/0 address (the first btc addr)
```