### PR TITLE
adds handling for fetching more than 10 addresses

### DIFF
--- a/src/__test__/e2e/api.test.ts
+++ b/src/__test__/e2e/api.test.ts
@@ -6,6 +6,8 @@ import { encode } from 'rlp';
 import {
   fetchActiveWallets,
   fetchAddresses,
+  fetchBtcLegacyAddresses,
+  fetchBtcSegwitAddresses,
   pair,
   signBtcLegacyTx,
   signBtcSegwitTx,
@@ -154,6 +156,26 @@ describe('API', () => {
     test('fetchAddresses', async () => {
       const addresses = await fetchAddresses();
       expect(addresses).toHaveLength(10);
+    });
+
+    test('fetchAddresses[1]', async () => {
+      const addresses = await fetchAddresses({ n: 1 });
+      expect(addresses).toHaveLength(1);
+    });
+
+    test('fetchAddresses[12]', async () => {
+      const addresses = await fetchAddresses({ n: 12 });
+      expect(addresses).toHaveLength(12);
+    });
+
+    test('fetchBtcLegacyAddresses', async () => {
+      const addresses = await fetchBtcLegacyAddresses();
+      expect(addresses).toHaveLength(10);
+    });
+
+    test('fetchBtcSegwitAddresses[12]', async () => {
+      const addresses = await fetchBtcSegwitAddresses({ n: 12 });
+      expect(addresses).toHaveLength(12);
     });
 
     test('fetchLedgerLiveAddresses', async () => {

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -37,8 +37,6 @@ export const fetchAddresses = async (overrides?: GetAddressesRequestParams) => {
           }
         }),
     );
-    // Exit loop if we've fetched the requested number of addresses
-    if (totalFetched >= totalToFetch) break;
   }
 
   return allAddresses;


### PR DESCRIPTION
adds the ability to fetch an arbirary number of addresses using `fetchAddresses`

examples:

```ts

const addresses = await fetchAddresses({ n: 12 });
// returns 12 addresses

const addresses = await fetchBtcSegwitAddresses({ n: 12 });
// returns 12 addresses

const addresses = await fetchAddresses({ n: 12, startPathIndex: 100 });
// returns 12 addresses starting at the 100th index
```
