### PR TITLE
feat: support custom app secret in the `setup()` call + EVM signTypedData fixes

### DIFF
--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -1,6 +1,6 @@
 import { Utils } from '..';
 import { Client } from '../client';
-import { setSaveClient, setLoadClient, saveClient, loadClient } from './state';
+import { loadClient, saveClient, setLoadClient, setSaveClient } from './state';
 import { buildLoadClientFn, buildSaveClientFn, queue } from './utilities';
 
 /**
@@ -15,6 +15,7 @@ type SetupParameters = {
   deviceId: string;
   password: string;
   name: string;
+  appSecret?: Buffer;
   getStoredClient: () => string;
   setStoredClient: (clientData: string | null) => void;
 };
@@ -28,6 +29,7 @@ type SetupParameters = {
  * @param {string} SetupParameters.deviceId - the device id of the client
  * @param {string} SetupParameters.password - the password of the client
  * @param {string} SetupParameters.name - the name of the client
+ * @param {Buffer} SetupParameters.appSecret - if set, this app secret will be used instead of the default one
  * @param {Function} SetupParameters.getStoredClient - a function that returns the stored client data
  * @param {Function} SetupParameters.setStoredClient - a function that stores the client data
  * @returns {Promise<boolean>} - a promise that resolves to a boolean that indicates whether the Client is paired to the application to which it's attempting to connect
@@ -37,6 +39,7 @@ export const setup = async ({
   deviceId,
   password,
   name,
+  appSecret,
   getStoredClient,
   setStoredClient,
 }: SetupParameters): Promise<boolean> => {
@@ -47,7 +50,8 @@ export const setup = async ({
   setLoadClient(buildLoadClientFn(getStoredClient));
 
   if (deviceId && password && name) {
-    const privKey = Utils.generateAppSecret(deviceId, password, name);
+    const privKey =
+      appSecret ?? Utils.generateAppSecret(deviceId, password, name);
     const client = new Client({ deviceId, privKey, name });
     return client.connect(deviceId).then((isPaired) => {
       saveClient(client.getStateData());

--- a/src/ethereum.ts
+++ b/src/ethereum.ts
@@ -76,7 +76,7 @@ const validateEthereumMsgResponse = function (res, req) {
     const digest = prehash ? prehash : encoded;
     const chainId = parseInt(input.payload.domain.chainId, 16);
     // Get recovery param with a `v` value of [27,28] by setting `useEIP155=false`
-    return addRecoveryParam(digest, sig, signer, { chainId });
+    return addRecoveryParam(digest, sig, signer, { chainId, useEIP155: false });
   } else {
     throw new Error('Unsupported protocol');
   }


### PR DESCRIPTION
Motivation: We'd like to be able to use the setup method with the same flow that Metamask/Rabby wallets do (i.e. redirection through lattice connector which takes care of the pairing instead of custom logic within the wallet app) and for that we need to create the same app secret which is however not the case for the implementation of the setup() method (notice the different order of parameters passed to the hashing function which generates the app secret) :

Metamask/Rabby app secret: https://github.com/GridPlus/eth-lattice-keyring/blob/c22352bd35c895d25700f19d50ff932d680ec66a/index.js#L683-L686

gridplus-sdk setup implementation: https://github.com/GridPlus/gridplus-sdk/blob/68a8242fc55451fd61af9438ba7ddefdff4dba1a/src/util.ts#L666-L670

This PR solves our problem by exposing an optional `appSecret` parameter which allows to override the default `appSecret` generated in the `setup()` call

additionally, this PR addresses an issue we came across with `bignumber.js` being possibly encoded correctly, which happened if package manager chose to supply a different version of bignumber.js to gridplus-sdk vs the `borc` lib which is internally used to encode payloads. This should be prevented by making sure the version of `bignumber.js` required by `gridplus-sdk` matches exactly the one required by `borc`