### PR TITLE
fix: fix package build causing vitest to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "gridplus-sdk",
   "version": "3.4.0",
-  "type": "module",
   "description": "SDK to interact with GridPlus Lattice1 device",
   "scripts": {
     "build": "tsup",
@@ -38,21 +37,21 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
       },
       "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },
-  "types": "./dist/index.d.cts",
+  "types": "./dist/index.d.mts",
   "repository": {
     "type": "git",
     "url": "https://github.com/GridPlus/gridplus-sdk.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   vitest@2.1.3:
-    hash: vwmc6yhalpfduebrkyv2xq7etq
+    hash: 0c337a8de71c98b9a0e1f0e80ef2bf86e1b90fb9871b385fff2d2a2d93ed3ffd
     path: patches/vitest@2.1.3.patch
 
 importers:
@@ -181,7 +181,7 @@ importers:
         version: 4.3.0(@types/node@22.7.8)(rollup@4.24.0)(typescript@5.6.3)(vite@5.4.9(@types/node@22.7.8))
       vitest:
         specifier: 2.1.3
-        version: 2.1.3(patch_hash=vwmc6yhalpfduebrkyv2xq7etq)(@types/node@22.7.8)(msw@2.5.0(typescript@5.6.3))
+        version: 2.1.3(patch_hash=0c337a8de71c98b9a0e1f0e80ef2bf86e1b90fb9871b385fff2d2a2d93ed3ffd)(@types/node@22.7.8)(msw@2.5.0(typescript@5.6.3))
 
 packages:
 
@@ -5619,7 +5619,7 @@ snapshots:
       '@types/node': 22.7.8
       fsevents: 2.3.3
 
-  vitest@2.1.3(patch_hash=vwmc6yhalpfduebrkyv2xq7etq)(@types/node@22.7.8)(msw@2.5.0(typescript@5.6.3)):
+  vitest@2.1.3(patch_hash=0c337a8de71c98b9a0e1f0e80ef2bf86e1b90fb9871b385fff2d2a2d93ed3ffd)(@types/node@22.7.8)(msw@2.5.0(typescript@5.6.3)):
     dependencies:
       '@vitest/expect': 2.1.3
       '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(msw@2.5.0(typescript@5.6.3))(vite@5.4.9(@types/node@22.7.8))


### PR DESCRIPTION
After updating to the latest version of `gridplus-sdk`, our unit tests (ran in node environment) started crashing with the following error

```
Error: Directory import '<project>/node_modules/hash.js/lib/hash/sha' is not supported resolving ES modules imported from /<project>/node_modules/gridplus-sdk/dist/index.js
Did you mean to import hash.js/lib/hash/sha.js?
```

We don't use gridplus-sdk directly in the files being tested, but it's apparently bundled nevertheless, leading to the error above.

Turns out that the package's type "module" recently introduced in this [commit](https://github.com/GridPlus/gridplus-sdk/commit/de67e71a9466d9be609899717dbdd31ddd77a741#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R4-R9) was causing this - after removing it, the tests started to work again while the web app seemed unaffected and Gridplus worked there fine as well.