### PR TITLE
fix: improve EVM test compatibility with Lattice simulator

### DIFF
--- a/src/__test__/utils/runners.ts
+++ b/src/__test__/utils/runners.ts
@@ -101,25 +101,7 @@ export async function runEvm(
     true,
     'Signature failed to verify',
   );
-  if (process.env.DEBUG_EVM_SIGN === '1') {
-    console.debug('[runEvm] lattice signature components', {
-      r: Buffer.from(sig.r).toString('hex'),
-      s: Buffer.from(sig.s).toString('hex'),
-      v: sig.v?.toString('hex'),
-      pubkey: resp.pubkey ? Buffer.from(resp.pubkey).toString('hex') : null,
-    });
-    console.debug('[runEvm] reference signature components', {
-      r: signedTx.r?.toString(16),
-      s: signedTx.s?.toString(16),
-      pubkey: (() => {
-        try {
-          return Buffer.from(tx.getSenderPublicKey()).toString('hex');
-        } catch (err) {
-          return `error:${(err as Error).message}`;
-        }
-      })(),
-    });
-  }
+
   const refR = ensureHexBuffer(signedTx.r?.toString(16));
   const refS = ensureHexBuffer(signedTx.s?.toString(16));
 
@@ -186,24 +168,7 @@ export async function runEvm(
   signedTxData.v = latticeV;
   signedTxData.r = latticeR;
   signedTxData.s = latticeS;
-  if (process.env.DEBUG_EVM_SIGN === '1') {
-    const typeSummary = Object.fromEntries(
-      Object.entries(signedTxData).map(([key, value]) => {
-        if (Buffer.isBuffer(value)) {
-          return [key, { type: 'Buffer', length: value.length }];
-        }
-        const valueType = typeof value;
-        return [key, {
-          type: valueType,
-          value:
-            valueType === 'bigint'
-              ? (value as bigint).toString()
-              : value,
-        }];
-      }),
-    );
-    console.debug('[runEvm] signedTxData summary', typeSummary);
-  }
+
   const verifTx = EthTxFactory.fromTxData(signedTxData, {
     common: req.common,
   });

--- a/src/__test__/utils/runners.ts
+++ b/src/__test__/utils/runners.ts
@@ -8,7 +8,6 @@ import {
 } from './helpers';
 import { initializeSeed } from './initializeClient';
 import { testRequest } from './testRequest';
-import BN from 'bn.js';
 import { Constants } from '../..';
 import { TransactionFactory as EthTxFactory } from '@ethereumjs/tx';
 import { RLP } from '@ethereumjs/rlp';
@@ -102,6 +101,25 @@ export async function runEvm(
     true,
     'Signature failed to verify',
   );
+  if (process.env.DEBUG_EVM_SIGN === '1') {
+    console.debug('[runEvm] lattice signature components', {
+      r: Buffer.from(sig.r).toString('hex'),
+      s: Buffer.from(sig.s).toString('hex'),
+      v: sig.v?.toString('hex'),
+      pubkey: resp.pubkey ? Buffer.from(resp.pubkey).toString('hex') : null,
+    });
+    console.debug('[runEvm] reference signature components', {
+      r: signedTx.r?.toString(16),
+      s: signedTx.s?.toString(16),
+      pubkey: (() => {
+        try {
+          return Buffer.from(tx.getSenderPublicKey()).toString('hex');
+        } catch (err) {
+          return `error:${(err as Error).message}`;
+        }
+      })(),
+    });
+  }
   const refR = ensureHexBuffer(signedTx.r?.toString(16));
   const refS = ensureHexBuffer(signedTx.s?.toString(16));
 
@@ -118,9 +136,37 @@ export async function runEvm(
   // Get params from Lattice sig
   const latticeR = Buffer.from(sig.r);
   const latticeS = Buffer.from(sig.s);
-
-  // Get the V parameter or y-parity value depending on transaction type
-  const latticeV = getSignatureVBN(tx, resp);
+  const latticeV = (() => {
+    const value = sig.v;
+    if (value === null || value === undefined) {
+      return 0n;
+    }
+    if (typeof value === 'bigint') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      return BigInt(value);
+    }
+    if (typeof value === 'string') {
+      const normalized = value.startsWith('0x') ? value : `0x${value}`;
+      return BigInt(normalized);
+    }
+    if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+      const hex = Buffer.from(value).toString('hex');
+      return hex ? BigInt(`0x${hex}`) : 0n;
+    }
+    if (typeof (value as any)?.toArray === 'function') {
+      const hex = Buffer.from((value as any).toArray('be')).toString('hex');
+      return hex ? BigInt(`0x${hex}`) : 0n;
+    }
+    if (typeof (value as any)?.toString === 'function') {
+      const str = (value as any).toString();
+      if (/^0x[0-9a-f]+$/i.test(str) || /^[0-9]+$/i.test(str)) {
+        return BigInt(str.startsWith('0x') ? str : `0x${str}`);
+      }
+    }
+    return 0n;
+  })();
 
   // Validate the signature
   expect(latticeR.equals(refR)).toEqualElseLog(
@@ -140,6 +186,24 @@ export async function runEvm(
   signedTxData.v = latticeV;
   signedTxData.r = latticeR;
   signedTxData.s = latticeS;
+  if (process.env.DEBUG_EVM_SIGN === '1') {
+    const typeSummary = Object.fromEntries(
+      Object.entries(signedTxData).map(([key, value]) => {
+        if (Buffer.isBuffer(value)) {
+          return [key, { type: 'Buffer', length: value.length }];
+        }
+        const valueType = typeof value;
+        return [key, {
+          type: valueType,
+          value:
+            valueType === 'bigint'
+              ? (value as bigint).toString()
+              : value,
+        }];
+      }),
+    );
+    console.debug('[runEvm] signedTxData summary', typeSummary);
+  }
   const verifTx = EthTxFactory.fromTxData(signedTxData, {
     common: req.common,
   });

--- a/src/__test__/utils/setup.ts
+++ b/src/__test__/utils/setup.ts
@@ -40,18 +40,25 @@ export const getStoredClient = async () => {
 
 export const setupClient = async () => {
   const deviceId = process.env.DEVICE_ID;
+  const baseUrl = process.env.baseUrl || 'https://signing.gridpl.us';
   const password = process.env.PASSWORD || 'password';
   const name = process.env.APP_NAME || 'SDK Test';
+  const pairingSecret = process.env.PAIRING_SECRET || '12345678';
+  console.log(`deviceId: ${deviceId}, baseUrl: ${baseUrl}, password: ${password}, name: ${name}`);
   const isPaired = await setup({
     deviceId,
     password,
     name,
+    baseUrl,
     getStoredClient,
     setStoredClient,
   });
   if (!isPaired) {
-    const secret = question('Please enter the pairing secret: ');
-    await pair(secret.toUpperCase());
+    if (!pairingSecret) {
+      throw new Error('PAIRING_SECRET environment variable required for pairing');
+    }
+    console.log(`Using pairing secret from environment`);
+    await pair(pairingSecret.toUpperCase());
   }
   return getClient();
 };

--- a/src/__test__/utils/setup.ts
+++ b/src/__test__/utils/setup.ts
@@ -44,7 +44,6 @@ export const setupClient = async () => {
   const password = process.env.PASSWORD || 'password';
   const name = process.env.APP_NAME || 'SDK Test';
   const pairingSecret = process.env.PAIRING_SECRET || '12345678';
-  console.log(`deviceId: ${deviceId}, baseUrl: ${baseUrl}, password: ${password}, name: ${name}`);
   const isPaired = await setup({
     deviceId,
     password,

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -20,6 +20,7 @@ type SetupParameters =
       appSecret?: string;
       getStoredClient: () => Promise<string>;
       setStoredClient: (clientData: string | null) => Promise<void>;
+      baseUrl?: string;
     }
   | {
       getStoredClient: () => Promise<string>;
@@ -56,6 +57,7 @@ export const setup = async (params: SetupParameters): Promise<boolean> => {
       deviceId: params.deviceId,
       privKey,
       name: params.name,
+      baseUrl: params.baseUrl,
     });
     return client.connect(params.deviceId).then(async (isPaired) => {
       await saveClient(client.getStateData());


### PR DESCRIPTION
## Summary

  Updates EVM transaction signing tests to work seamlessly with the Lattice simulator environment while maintaining compatibility with hardware devices.

  ## Changes

  - **Test Setup**: Add support for `baseUrl` and `PAIRING_SECRET` environment variables to enable automated pairing with the simulator
  - **Signature Handling**: Replace deprecated `BN` usage with native `bigint` for signature `v` component handling
  - **Type Safety**: Add comprehensive type conversion for signature `v` values to handle various input formats (Buffer, hex string, number, bigint, etc.)
  - **Cleanup**: Remove debug logging code

  ## Test Plan

  - Verify EVM signing tests pass against Lattice simulator with environment variables:
    - `baseUrl=http://127.0.0.1:3000`
    - `PAIRING_SECRET=12345678`
    - `DEVICE_ID=SD0001`
  - Confirm backward compatibility with existing hardware device tests


`DEBUG_EVM_SIGN=1 baseUrl=http://127.0.0.1:3000 DEVICE_ID=SD0001 PASSWORD=12345678 APP_NAME=lattice-manager pnpm e2e-sign-evm-tx`