### PR TITLE
ci: add lattice-simulator e2e tests to PR checks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,16 @@
-name: Build
+name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - 'release/**'
+  pull_request:
+    branches:
+      - main
+      - dev
+      - 'release/**'
 
 jobs:
   build:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,3 +35,72 @@ jobs:
 
       - name: Release a nightly build
         run: pnpx pkg-pr-new publish
+
+      - name: Checkout lattice-simulator
+        uses: actions/checkout@v3
+        with:
+          repository: GridPlus/lattice-simulator
+          path: lattice-simulator
+
+      - name: Install simulator dependencies
+        working-directory: lattice-simulator
+        run: pnpm install
+
+      - name: Start simulator in background
+        working-directory: lattice-simulator
+        env:
+          CI: "1"
+          DEBUG_SIGNING: "1"
+          DEBUG: "lattice*"
+          LATTICE_MNEMONIC: "test test test test test test test test test test test junk"
+          PORT: "3000"
+          DEVICE_ID: "SD0001"
+          PASSWORD: "12345678"
+          PAIRING_SECRET: "12345678"
+          ENC_PW: "12345678"
+        run: |
+          pnpm run dev > simulator.log 2>&1 &
+          echo $! > simulator.pid
+          echo "Simulator PID: $(cat simulator.pid)"
+
+          # Wait for simulator to be ready
+          echo "Waiting for simulator to start..."
+          for i in {1..30}; do
+            if curl -s http://localhost:3000 > /dev/null 2>&1; then
+              echo "Simulator is ready!"
+              break
+            fi
+            if [ $i -eq 30 ]; then
+              echo "Simulator failed to start within 30 seconds"
+              cat simulator.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run SDK e2e tests with simulator
+        env:
+          CI: "1"
+          DEBUG_SIGNING: "1"
+          baseUrl: "http://127.0.0.1:3000"
+          DEVICE_ID: "SD0001"
+          PASSWORD: "12345678"
+          PAIRING_SECRET: "12345678"
+          ENC_PW: "12345678"
+          APP_NAME: "lattice-manager"
+        run: pnpm run e2e --reporter=basic
+
+      - name: Show simulator logs on failure
+        if: failure()
+        working-directory: lattice-simulator
+        run: |
+          echo "=== Simulator logs ==="
+          cat simulator.log || echo "No simulator logs found"
+
+      - name: Stop simulator
+        if: always()
+        working-directory: lattice-simulator
+        run: |
+          if [ -f simulator.pid ]; then
+            kill $(cat simulator.pid) || true
+          fi

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -83,6 +83,7 @@ jobs:
           done
 
       - name: Run SDK e2e tests with simulator
+        working-directory: ${{ github.workspace }}
         env:
           CI: "1"
           DEBUG_SIGNING: "1"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - name: Checkout code
@@ -41,6 +44,7 @@ jobs:
         with:
           repository: GridPlus/lattice-simulator
           path: lattice-simulator
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install simulator dependencies
         working-directory: lattice-simulator

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: GridPlus/lattice-simulator
           path: lattice-simulator
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GRIDPLUS_SIM_PAT }}
 
       - name: Install simulator dependencies
         working-directory: lattice-simulator

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Lint, Build & Unit, E2E Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/ethereum.ts
+++ b/src/ethereum.ts
@@ -1026,6 +1026,10 @@ function parseEIP712Item(data, type, forJSParser = false) {
     // Fixed sizes bytes need to be buffer type. We also add some sanity checks.
     const nBytes = parseInt(type.slice(5));
     data = ensureHexBuffer(data);
+    // Edge case to handle empty bytesN values
+    if (data.length === 0) {
+      data = Buffer.alloc(nBytes);
+    }
     if (data.length !== nBytes)
       throw new Error(`Expected ${type} type, but got ${data.length} bytes`);
     if (forJSParser) {


### PR DESCRIPTION
Integrate lattice-simulator testing into the CI pipeline by:
- Checking out and installing the lattice-simulator
- Starting simulator in background with test configuration
- Running SDK e2e tests against the live simulator
- Capturing and displaying simulator logs on failure

This ensures that simulator compatibility is validated on every push.