### PR TITLE
ci: add pull_request_target support for Dependabot with secrets

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,15 @@ on:
       - main
       - dev
       - 'release/**'
+  pull_request_target:
+    branches:
+      - main
+      - dev
+      - 'release/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   build:
@@ -19,10 +28,21 @@ jobs:
     permissions:
       contents: read
       packages: read
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
 
     steps:
       - name: Checkout code
+        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v3
+
+      - name: Checkout code (Dependabot PR)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Summary
- Enable CI workflow to run on Dependabot PRs by adding pull_request_target trigger with conditional logic. 
- Separates checkout steps to safely handle both regular PRs and Dependabot PRs, allowing Dependabot to access secrets needed for simulator e2e tests while maintaining security boundaries.

### What was the issue?
> GitHub won’t expose repository secrets (like GRIDPLUS_SIM_PAT) to workflows that run on pull_request events opened by Dependabot; that’s why the checkout of the private lattice simulator failed.

<img width="1766" height="1264" alt="image" src="https://github.com/user-attachments/assets/654b5893-b3e4-4e59-9847-68b832360b54" />

