### PR TITLE
test: add module interoperability tests for cjs and esm

### DIFF
--- a/src/__test__/unit/module.interop.test.ts
+++ b/src/__test__/unit/module.interop.test.ts
@@ -1,0 +1,104 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync, spawnSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '../../..');
+const cjsOutput = path.resolve(packageRoot, 'dist/index.cjs');
+const esmOutput = path.resolve(packageRoot, 'dist/index.mjs');
+const packageName = 'gridplus-sdk';
+
+let built = false;
+let fixtureDir: string | undefined;
+
+const ensureBuildArtifacts = () => {
+  if (built) {
+    return;
+  }
+  console.log('Building package with pnpm run build ...');
+  execSync('pnpm run build', {
+    cwd: packageRoot,
+    stdio: 'inherit',
+  });
+  if (!existsSync(cjsOutput) || !existsSync(esmOutput)) {
+    throw new Error('Expected dual build outputs were not generated');
+  }
+  built = true;
+};
+
+const ensureLinkedFixture = () => {
+  if (fixtureDir) {
+    return fixtureDir;
+  }
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'gridplus-sdk-interop-'));
+  const nodeModulesDir = path.join(tmpDir, 'node_modules');
+  mkdirSync(nodeModulesDir, { recursive: true });
+  const linkTarget = path.join(nodeModulesDir, packageName);
+  symlinkSync(packageRoot, linkTarget, 'junction');
+  fixtureDir = tmpDir;
+  return fixtureDir;
+};
+
+const runNodeCheck = (args: string[]) => {
+  const cwd = ensureLinkedFixture();
+  const result = spawnSync(process.execPath, args, {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf-8',
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Node command failed (${result.status}):\n${result.stderr || result.stdout}`,
+    );
+  }
+};
+
+describe('package module interoperability', () => {
+  beforeAll(() => {
+    ensureBuildArtifacts();
+  });
+  afterAll(() => {
+    if (fixtureDir) {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      fixtureDir = undefined;
+    }
+  });
+
+  it('exposes CommonJS entry via require()', () => {
+    const script = `
+      const sdk = require('${packageName}');
+      if (typeof sdk.connect !== 'function') {
+        throw new Error('connect export missing');
+      }
+      if (typeof sdk.Client !== 'function') {
+        throw new Error('Client export missing');
+      }
+    `;
+    runNodeCheck(['-e', script]);
+  });
+
+  it('exposes ESM entry via dynamic import()', () => {
+    const script = `
+      const sdk = await import('${packageName}');
+      if (typeof sdk.connect !== 'function') {
+        throw new Error('connect export missing');
+      }
+      if (typeof sdk.Client !== 'function') {
+        throw new Error('Client export missing');
+      }
+    `;
+    runNodeCheck(['--input-type=module', '-e', script]);
+  });
+});


### PR DESCRIPTION
## 📝 Summary

This PR adds module interoperability tests to verify that the SDK works correctly with both CommonJS (`require()`) and ES Module (`import()`) usage patterns. The tests ensure that core exports (`connect` and `Client`) are accessible regardless of the module system used.

## 🔧 Context / Implementation

The test suite now includes a new `module.interop.test.ts` file that:

- **Creates isolated test environments**: Uses temporary directories with symlinked package installations to test real-world module resolution
- **Tests CommonJS usage**: Verifies that `require('gridplus-sdk')` correctly resolves and exposes expected exports
- **Tests ES Module usage**: Verifies that `import('gridplus-sdk')` works correctly with dynamic imports
- **Validates exports**: Ensures both `connect` function and `Client` class are available in both module formats

The tests build the package before running to ensure they test against actual build artifacts, providing confidence that the published package will work correctly in both module systems.

## 🧪 Test Plan

1. Run `pnpm test` to execute all unit tests including the new module interoperability tests
2. Expected result: All tests pass, confirming both `require('gridplus-sdk')` and `import('gridplus-sdk')` work correctly
3. Verify the test creates temporary directories and symlinks the package correctly
