### PR TITLE
ci: only allow internal events to trigger simulator run

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,15 +11,6 @@ on:
       - main
       - dev
       - 'release/**'
-  pull_request_target:
-    branches:
-      - main
-      - dev
-      - 'release/**'
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 jobs:
   build:
@@ -28,21 +19,12 @@ jobs:
     permissions:
       contents: read
       packages: read
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+    env:
+      INTERNAL_EVENT: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       - name: Checkout code
-        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v5
-
-      - name: Checkout code (Dependabot PR)
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -67,9 +49,11 @@ jobs:
         run: pnpm run build
 
       - name: Release a nightly build
+        if: env.INTERNAL_EVENT == 'true'
         run: pnpx pkg-pr-new publish
 
       - name: Checkout lattice-simulator
+        if: env.INTERNAL_EVENT == 'true'
         uses: actions/checkout@v5
         with:
           repository: GridPlus/lattice-simulator
@@ -77,10 +61,12 @@ jobs:
           token: ${{ secrets.GRIDPLUS_SIM_PAT }}
 
       - name: Install simulator dependencies
+        if: env.INTERNAL_EVENT == 'true'
         working-directory: lattice-simulator
         run: pnpm install
 
       - name: Start simulator in background
+        if: env.INTERNAL_EVENT == 'true'
         working-directory: lattice-simulator
         env:
           CI: '1'
@@ -113,6 +99,7 @@ jobs:
           done
 
       - name: Run SDK e2e tests with simulator
+        if: env.INTERNAL_EVENT == 'true'
         working-directory: ${{ github.workspace }}
         env:
           CI: '1'
@@ -126,14 +113,14 @@ jobs:
         run: pnpm run e2e --reporter=basic
 
       - name: Show simulator logs on failure
-        if: failure()
+        if: failure() && env.INTERNAL_EVENT == 'true'
         working-directory: lattice-simulator
         run: |
           echo "=== Simulator logs ==="
           cat simulator.log || echo "No simulator logs found"
 
       - name: Stop simulator
-        if: always()
+        if: always() && env.INTERNAL_EVENT == 'true'
         working-directory: lattice-simulator
         run: |
           if [ -f simulator.pid ]; then


### PR DESCRIPTION
## 📝 Summary
- Removed the pull_request_target trigger and gated secret-consuming steps behind an INTERNAL_EVENT check so forked PRs can’t execute workflows with repo secrets.
- Restored nightly publishes for trusted runs while keeping them disabled for forks.


## 🔧 Context / Implementation
- Added an INTERNAL_EVENT flag (github.event_name != 'pull_request' || head.repo.full_name == github.repository) to distinguish trusted events; forked PRs now skip simulator/secret steps entirely.
- Nightly publish now runs whenever INTERNAL_EVENT == true, so trusted PR branches and pushes behave like before, but untrusted forks cannot reach that step.
- The goal is to close the reported RCE vector (Dependabot commit + pull_request_target) while ensuring that even if GRIDPLUS_SIM_PAT were exposed it has only read/checkout scope.

## 🧪 Test Plan
- Push to a branch in this repo: verify lint/build/tests + simulator e2e + nightly publish all run.
- Open a PR from the same repo (or Dependabot): INTERNAL_EVENT is true, so simulator steps run and nightly publish triggers.
- Open a PR from a fork: INTERNAL_EVENT is false; workflow runs lint/build/tests but skips simulator steps and nightly publish.