### PR TITLE
fix: resolve all eslint warnings

### DIFF
--- a/src/__test__/e2e/api.test.ts
+++ b/src/__test__/e2e/api.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable quotes */
-
 vi.mock('../../functions/fetchDecoder.ts', () => ({
   fetchDecoder: vi.fn().mockResolvedValue(undefined),
 }));
@@ -23,7 +21,6 @@ vi.mock('../../util', async () => {
 });
 
 import { RLP } from '@ethereumjs/rlp';
-import { question } from 'readline-sync';
 import { getClient } from './../../api/utilities';
 import {
   fetchActiveWallets,
@@ -34,7 +31,6 @@ import {
   fetchBtcLegacyAddresses,
   fetchBtcSegwitAddresses,
   fetchSolanaAddresses,
-  pair,
   signBtcLegacyTx,
   signBtcSegwitTx,
   signBtcWrappedSegwitTx,

--- a/src/__test__/e2e/contracts.test.ts
+++ b/src/__test__/e2e/contracts.test.ts
@@ -7,8 +7,6 @@ import { fileURLToPath } from 'node:url';
 import {
   type Account,
   type Address,
-  type PublicClient as ViemPublicClient,
-  type WalletClient as ViemWalletClient,
   createPublicClient,
   createWalletClient,
   http,
@@ -50,7 +48,6 @@ describeContract('NegativeAmountHandler', () => {
   let publicClient;
   let walletClient;
   let account: Account;
-  let contract: undefined;
   let abi: any[];
 
   beforeAll(async () => {

--- a/src/__test__/e2e/solana/addresses.test.ts
+++ b/src/__test__/e2e/solana/addresses.test.ts
@@ -27,6 +27,7 @@ describe('Solana Addresses', () => {
           expect(isOnCurve).toBe(true);
           return true;
         } catch (e) {
+          console.error('Invalid Solana public key:', e);
           return false;
         }
       })

--- a/src/__test__/e2e/wallet-jobs.test.ts
+++ b/src/__test__/e2e/wallet-jobs.test.ts
@@ -437,6 +437,7 @@ describe('Test Wallet Jobs', () => {
         // Should fail to export keys from a path with unhardened indices
         await client.getAddresses(req);
       } catch (err) {
+        console.error('Expected error for unhardened indices:', err);
         // Convert to all hardened indices and expect success
         req.startPath[2] = HARDENED_OFFSET;
         const pubkeys = await client.getAddresses(req);

--- a/src/__test__/e2e/xpub.test.ts
+++ b/src/__test__/e2e/xpub.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 import { fetchBtcXpub, fetchBtcYpub, fetchBtcZpub } from '../../api';
 import { setupClient } from '../utils/setup';
 

--- a/src/__test__/utils/helpers.ts
+++ b/src/__test__/utils/helpers.ts
@@ -274,7 +274,6 @@ function _get_reference_sighashes(
   isTestnet,
   purpose,
 ) {
-  const coin = isTestnet ? BTC_TESTNET_COIN : BTC_COIN;
   const network = isTestnet
     ? bitcoin.networks.testnet
     : bitcoin.networks.bitcoin;

--- a/src/__test__/utils/runners.ts
+++ b/src/__test__/utils/runners.ts
@@ -5,7 +5,6 @@ import {
   deriveSECP256K1Key,
   parseWalletJobResp,
   validateGenericSig,
-  getSignatureVBN,
 } from './helpers';
 import { initializeSeed } from './initializeClient';
 import { testRequest } from './testRequest';

--- a/src/__test__/utils/setup.ts
+++ b/src/__test__/utils/setup.ts
@@ -10,6 +10,7 @@ export async function setStoredClient(data: string) {
   try {
     fs.writeFileSync(TEMP_CLIENT_FILE, data);
   } catch (err) {
+    console.error('Failed to store client data:', err);
     return;
   }
 }
@@ -18,6 +19,7 @@ export async function getStoredClient() {
   try {
     return fs.readFileSync(TEMP_CLIENT_FILE, 'utf8');
   } catch (err) {
+    console.error('Failed to read stored client data:', err);
     return '';
   }
 }

--- a/src/bitcoin.ts
+++ b/src/bitcoin.ts
@@ -394,6 +394,7 @@ function decodeAddress(address) {
     versionByte = bs58check.decode(address)[0];
     pkh = Buffer.from(bs58check.decode(address).slice(1));
   } catch (err) {
+    console.error('Failed to decode base58 address, trying bech32:', err);
     // If we could not base58 decode, the address must be bech32 encoded.
     // If neither decoding method works, the address is invalid.
     try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -401,7 +401,7 @@ export class Client {
       };
       return JSON.stringify(data);
     } catch (err) {
-      console.warn('Could not pack state data.');
+      console.warn('Could not pack state data:', err);
       return null;
     }
   }
@@ -449,7 +449,7 @@ export class Client {
       this.timeout = unpacked.timeout;
       this.retryWrapper = buildRetryWrapper(this, this.retryCount);
     } catch (err) {
-      console.warn('Could not apply state data.');
+      console.warn('Could not apply state data:', err);
     }
   }
 }

--- a/src/ethereum.ts
+++ b/src/ethereum.ts
@@ -723,6 +723,7 @@ function isValidChainIdHexNumStr(s) {
     const b = new BN(s, 16);
     return b.isNaN() === false;
   } catch (err) {
+    console.error('Invalid chain ID hex string:', err);
     return false;
   }
 }

--- a/src/genericSigning.ts
+++ b/src/genericSigning.ts
@@ -293,6 +293,10 @@ export const parseGenericSigningResponse = function (res, off, req) {
           parsed.sig.v = BigInt(vBn.toString());
           populateViemSignedTx(parsed.sig.v, req, parsed);
         } catch (err) {
+          console.error(
+            'Failed to get V from transaction, using fallback:',
+            err,
+          );
           // Fall back to simple recovery if getV fails (e.g., malformed RLP)
           // Use the correct hash type specified in the request
           const msgHash = computeMessageHash(req, digestFromResponse);

--- a/src/shared/functions.ts
+++ b/src/shared/functions.ts
@@ -43,6 +43,7 @@ export const buildTransaction = ({
     try {
       payload = ethereum.convertEthereumTransactionToGenericRequest(data);
     } catch (err) {
+      console.error('Failed to convert legacy Ethereum transaction:', err);
       throw new Error(
         'Could not convert legacy request. Please switch to a general signing ' +
           'request. See gridplus-sdk docs for more information.',

--- a/src/shared/validators.ts
+++ b/src/shared/validators.ts
@@ -68,6 +68,7 @@ export const validateUrl = (url?: string) => {
   try {
     new URL(url);
   } catch (err) {
+    console.error('Invalid URL format:', err);
     throw new Error('Invalid URL provided. Please use a valid URL.');
   }
   return url;
@@ -80,6 +81,7 @@ export const validateBaseUrl = (baseUrl?: string) => {
   try {
     new URL(baseUrl);
   } catch (err) {
+    console.error('Invalid Base URL format:', err);
     throw new Error('Invalid Base URL provided. Please use a valid URL.');
   }
   return baseUrl;
@@ -227,6 +229,7 @@ export const isValidBlockExplorerResponse = (data: any) => {
     const result = JSON.parse(data.result);
     return !isEmpty(result);
   } catch (err) {
+    console.error('Invalid block explorer response:', err);
     return false;
   }
 };
@@ -235,6 +238,7 @@ export const isValid4ByteResponse = (data: any) => {
   try {
     return !isEmpty(data.results);
   } catch (err) {
+    console.error('Invalid 4byte response:', err);
     return false;
   }
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -401,6 +401,7 @@ export function selectDefFrom4byteABI(abiData: any[], selector: string) {
         );
         return !!def;
       } catch (_err) {
+        console.error('Failed to parse canonical name:', _err);
         return false;
       }
     });
@@ -574,6 +575,7 @@ async function replaceNestedDefs(possNestedDefs) {
             );
             _nestedDefs.push(_nestedDef);
           } catch (_err) {
+            console.error('Failed to fetch nested 4byte data:', _err);
             shouldInclude = false;
             _nestedDefs.push(null);
           }
@@ -590,6 +592,7 @@ async function replaceNestedDefs(possNestedDefs) {
           const nestedDef = selectDefFrom4byteABI(nestedAbi, nestedSelector);
           nestedDefs.push(nestedDef);
         } catch (_err) {
+          console.error('Failed to fetch nested definition:', _err);
           nestedDefs.push(null);
         }
       }
@@ -749,6 +752,7 @@ export const getV = function (tx: any, resp: any) {
         }
       }
     } catch (err) {
+      console.error('Failed to parse transaction, trying legacy format:', err);
       try {
         const txBufRaw = Buffer.isBuffer(tx)
           ? tx


### PR DESCRIPTION
## 📝 Summary
- Remove unused eslint-disable directives
- Add error logging to all unused error variables in catch blocks
- Remove unused imports and variables
- Fix prettier formatting issues

## Test Plan
- `pnpm lint` runs without an error