### PR TITLE
test: update error msg to invalid request

### DIFF
--- a/src/__test__/e2e/eth.msg.test.ts
+++ b/src/__test__/e2e/eth.msg.test.ts
@@ -100,7 +100,7 @@ describe('ETH Messages', () => {
       // Using a zero length payload should auto-reject
       await expect(
         client.sign(buildEthMsgReq(zeroInvalid, protocol)),
-      ).rejects.toThrow(/Invalid Ethereum signature returned./);
+      ).rejects.toThrow(/Invalid Request/);
     });
 
     describe(`Test ${5} random payloads`, () => {


### PR DESCRIPTION
## 📝 Summary
- Align ETH message E2E test expectation with the simulator’s updated error string so zero-length payload rejections match the current “Invalid Request” response.

## <!-- Short description of what this PR does and what was the issue? -->
- Previously the test expected `Invalid Ethereum signature returned.` which no longer matches runtime behavior, causing false negatives.

## 🔧 Context / Implementation
- Update `src/__test__/e2e/eth.msg.test.ts` to assert `/Invalid Request/` when signing an empty payload.
- Keeps test coverage in sync with the simulator fix that now throws the new message.

## <!-- Brief explanation of the change, reasoning, or relevant background -->
- Ensures SDK tests validate the correct failure mode after the upstream parser started respecting zero-length declarations.

## 🧪 Test Plan
1. `npm test -- eth.msg.test.ts`
2. Focus on the “ETH Messages” suite and run the zero-length payload case.
3. Expect the test to pass, confirming the new error regex matches the thrown message.

## 🖼️ Screenshots (if applicable)
| Before | After |
| ------ | ----- |
| Test failed because it matched the old `Invalid Ethereum signature returned.` text. | Test passes by matching the new `Invalid Request` error emitted by the simulator. |

<!--
## ✅ Checklist
- [x] Follows **conventional commit** style (`feat:`, `fix:`, `chore:`, etc.)
- [x] Tests / CI checks pass
- [ ] Reviewed and approved by required **CODEOWNERS**
- [ ] Branch is up-to-date and ready to merge
-->
