### PR TITLE
fix(sdk): add base-url env param to setup

### DIFF
--- a/packages/sdk/scripts/pair-device.ts
+++ b/packages/sdk/scripts/pair-device.ts
@@ -31,6 +31,7 @@ async function main() {
   console.log('GridPlus SDK Device Pairing Tool\n');
 
   try {
+    const baseUrl = process.env.baseUrl || 'https://signing.gridpl.us'
     // Get device configuration
     const deviceId = process.env.DEVICE_ID || question('Enter Device ID: ');
     const password =
@@ -53,6 +54,7 @@ async function main() {
       name,
       getStoredClient,
       setStoredClient,
+      baseUrl,
     });
 
     if (isPaired) {


### PR DESCRIPTION
## 📝 Summary
- Make the pair-device SDK script configurable via process.env.baseUrl
- Keep https://signing.gridpl.us as the default when no custom base URL is provided
- Pass the resolved baseUrl into the client setup so pairing can target non-default environments